### PR TITLE
Update example plugin for changes in napari/master, add CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,20 @@
+test_task:
+  auto_cancellation: true
+
+  env:
+    matrix:
+      - IMAGE: python:3.6-slim
+      - IMAGE: python:3.7-slim
+      - IMAGE: python:3.8-slim
+
+  name: ${$IMAGE}
+
+  container:
+    image: $IMAGE
+  
+  install_script:
+    - pip install pytest pytest-cookies tox
+
+  test_script:
+    - ${PY-python3} --version
+    - pytest -s

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,7 +7,7 @@ test_task:
       - IMAGE: python:3.7-slim
       - IMAGE: python:3.8-slim
 
-  name: ${$IMAGE}
+  name: $IMAGE
 
   container:
     image: $IMAGE

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,119 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+pip-wheel-metadata/
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/source/api/
+docs/source/release/
+docs/build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# Pycharm files
+.idea
+
+# OS stuff
+.DS_store
+
+# Benchmarking results
+.asv/
+
+# VSCode
+.vscode/

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ plugin_name [foobar]: growth-cone-finder
 module_name [growth_cone_finder]: growth_cone_finder
 short_description [A simple plugin to use with napari]:
 version [0.1.0]:
-napari_version [0.2.12]:
+minimum_napari_version [None]:
 Select docs_tool:
 1 - mkdocs
 2 - sphinx

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,7 +6,7 @@
     "module_name": "{{ cookiecutter.plugin_name|lower|replace('-', '_') }}",
     "short_description": "A simple plugin to use with napari",
     "version": "0.1.0",
-    "napari_version": "0.2.12",
+    "minimum_napari_version": "None",
     "docs_tool": [
         "mkdocs",
         "sphinx",

--- a/docs/user-guide/quickstart.md
+++ b/docs/user-guide/quickstart.md
@@ -41,7 +41,7 @@ plugin_name [foobar]: growth-cone-finder
 module_name [growth_cone_finder]: growth_cone_finder
 short_description [A simple plugin to use with napari]:
 version [0.1.0]:
-napari_version [0.2.12]: 0.2.13
+minimum_napari_version [None]: 0.3.0
 ```
 
 The values in the square brackets (f.i. ``[foobar]``) are defaults for the according variables.

--- a/napari-{{cookiecutter.plugin_name}}/napari_{{cookiecutter.module_name}}.py
+++ b/napari-{{cookiecutter.plugin_name}}/napari_{{cookiecutter.module_name}}.py
@@ -1,18 +1,54 @@
-# -*- coding: utf-8 -*-
+"""
+This module is an example of a barebones plugin, using imageio.imread.
 
-from napari.plugins import hookimpl
-from napari.plugins.hookspecs import LayerData, ReaderFunction, Optional, List
+It implements the ``napari_get_reader`` hook specification, (to create
+a reader plugin) but your plugin may choose to implement any of the hook
+specifications offered by napari.
+
+Type annotations here are OPTIONAL!
+If you don't care to annotate the return types of your functions
+your plugin doesn't need to import, or even depend on napari at all!
+
+Replace code below accordingly.
+"""
+import imageio
+import numpy as np
+
+from pluggy import HookimplMarker
+
+# for optional type hints only, otherwise you can delete/ignore this stuff
+from typing import List, Optional, Union, Any, Tuple, Dict, Callable
+
+LayerData = Union[Tuple[Any], Tuple[Any, Dict], Tuple[Any, Dict, str]]
+PathLike = Union[str, List[str]]
+ReaderFunction = Callable[[PathLike], List[LayerData]]
+# END type hint stuff.
+
+napari_hook_implementation = HookimplMarker("napari")
+IMAGEIO_EXTENSIONS = tuple(set(x for f in imageio.formats for x in f.extensions))
 
 
-# type annotations here are optional
-# see napari hookspecs for details on hooks that can be implemented
+@napari_hook_implementation
+def napari_get_reader(path: PathLike) -> Optional[ReaderFunction]:
+    """A basic implementation of the napari_get_reader hook specification."""
+    if isinstance(path, list):
+        # reader plugins may be handed single path, or a list of paths.
+        # if it is a list, it is assumed to be an image stack...
+        # so we are only going to look at the first file.
+        path = path[0]
+    if not path.endswith(IMAGEIO_EXTENSIONS):
+        # if we know we cannot read the file, we immediately return None.
+        return None
+    # otherwise we return the *function* that can read ``path``.
+    return reader_function
 
 
-def my_tiff_reader(path: str) -> List[LayerData]:
-    return [(None, {"path": path})]
-
-
-@hookimpl
-def napari_get_reader(path: str) -> Optional[ReaderFunction]:
-    if path.endswith(".tif"):
-        return my_tiff_reader
+def reader_function(path: PathLike) -> List[LayerData]:
+    """Take a path or list of paths and return a list of LayerData tuples."""
+    paths = [path] if isinstance(path, str) else path
+    # stack a list of strings, but also works for a single path string
+    data = np.squeeze(np.stack([imageio.imread(_path) for _path in paths]))
+    # Readers are expected to return data as a list of tuples, where each tuple
+    # is (data, [meta_dict, [layer_type]])
+    meta = {}  # optional kwargs for the corresponding viewer.add_* method
+    return [(data, meta)]

--- a/napari-{{cookiecutter.plugin_name}}/setup.py
+++ b/napari-{{cookiecutter.plugin_name}}/setup.py
@@ -11,6 +11,14 @@ def read(fname):
     return codecs.open(file_path, encoding='utf-8').read()
 
 
+# Add your dependencies here
+install_requires = []
+
+{% if cookiecutter.minimum_napari_version != "None" -%}
+install_requires += ['napari>={{cookiecutter.minimum_napari_version}}'],
+{%- endif %}
+
+
 setup(
     name='napari-{{cookiecutter.plugin_name}}',
     version='{{cookiecutter.version}}',
@@ -24,7 +32,7 @@ setup(
     long_description=read('README.rst'),
     py_modules=['napari_{{cookiecutter.module_name}}'],
     python_requires='>=3.6',
-    install_requires=['napari>={{cookiecutter.napari_version}}'],
+    install_requires=install_requires,
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',

--- a/napari-{{cookiecutter.plugin_name}}/tests/test_{{cookiecutter.module_name}}.py
+++ b/napari-{{cookiecutter.plugin_name}}/tests/test_{{cookiecutter.module_name}}.py
@@ -7,7 +7,8 @@ from napari_{{cookiecutter.module_name}} import napari_get_reader
 # def test_reader():
 #     from tempfile import NamedTemporaryFile
 #     import numpy as np
-
+#
+#     # use your own `.ext` here
 #     with NamedTemporaryFile(suffix='.ext', delete=False) as tmp:
 #         out_data = np.random.rand(20, 20)
 #         # write_data_to_file(tmp.name, out_data)

--- a/napari-{{cookiecutter.plugin_name}}/tests/test_{{cookiecutter.module_name}}.py
+++ b/napari-{{cookiecutter.plugin_name}}/tests/test_{{cookiecutter.module_name}}.py
@@ -3,8 +3,28 @@
 from napari_{{cookiecutter.module_name}} import napari_get_reader
 
 
+# # the best test here would to use tempfile.NamedTemporaryFile
+# def test_reader():
+#     from tempfile import NamedTemporaryFile
+#     import numpy as np
+
+#     with NamedTemporaryFile(suffix='.ext', delete=False) as tmp:
+#         out_data = np.random.rand(20, 20)
+#         # write_data_to_file(tmp.name, out_data)
+#         reader = napari_get_reader(tmp)
+#         in_data = reader(tmp.name)
+#         assert np.allclose(out_data, in_data)
+
+
 def test_get_reader_hit():
     reader = napari_get_reader('fake.tif')
+    assert reader is not None
+    assert callable(reader)
+
+
+def test_get_reader_with_list():
+    # a better test here would use real data
+    reader = napari_get_reader(['fake.tif'])
     assert reader is not None
     assert callable(reader)
 

--- a/napari-{{cookiecutter.plugin_name}}/tox.ini
+++ b/napari-{{cookiecutter.plugin_name}}/tox.ini
@@ -8,7 +8,7 @@ deps = pytest
        numpy
        imageio
 {% endif -%}
-commands = pytest {posargs:tests}
+commands = pytest -v {posargs:tests}
 
 [testenv:flake8]
 skip_install = true

--- a/napari-{{cookiecutter.plugin_name}}/tox.ini
+++ b/napari-{{cookiecutter.plugin_name}}/tox.ini
@@ -3,8 +3,11 @@
 envlist = py36,py37,py38,pypy,flake8
 
 [testenv]
-deps = napari>={{cookiecutter.napari_version}}
-       pytest
+deps = pytest
+{%- if cookiecutter.plugin_name == "foo-bar" %}
+       numpy
+       imageio
+{% endif -%}
 commands = pytest {posargs:tests}
 
 [testenv:flake8]


### PR DESCRIPTION
This PR updates the example in `napari_{{cookiecutter.module_name}}.py` for https://github.com/napari/napari/pull/937

Specifically: I removed all napari imports (which is probably best practice), instead choosing to import the `@hook_implementation` marker from `pluggy` and typings from `typing`.

Though the focus of this cookiecutter is more on package structure (as opposed to reader plugin implementations), I also added many more comments on how to implement an example reader plugin.  When we eventually have other hook specifications, we can revisit the "example" we set in `napari_{{cookiecutter.module_name}}.py`