### PR TITLE
make BSD-3 default, add LGPL, change repo license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,22 +1,29 @@
-The MIT License (MIT)
+BSD 3-Clause License
 
-Copyright (c) 2020 Talley Lambert
+Copyright (c) 2020, Napari
+All rights reserved.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
 
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -32,10 +32,13 @@ Select docs_tool:
 3 - none
 Choose from 1, 2, 3 [1]: 1
 Select license:
-1 - MIT
-2 - BSD-3
-3 - GNU GPL v3.0
-Choose from 1, 2, 3 [1]: 2
+1 - BSD-3
+2 - MIT
+3 - Mozilla Public License 2.0
+4 - Apache Software License 2.0
+5 - GNU LGPL v3.0
+6 - GNU GPL v3.0
+Choose from 1, 2, 3, 4, 5, 6 (1, 2, 3, 4, 5, 6) [1]:
 INFO:post_gen_project:Moving files for mkdocs.
 ```
 
@@ -66,8 +69,8 @@ napari-growth-cone-finder/
   plugin
 - Continuous integration configuration for [Travis CI] and [AppVeyor]
 - Optional documentation with either [Sphinx] or [MkDocs]
-- Choose from several licenses, such as [MIT], [BSD-3], [Apache v2.0], [GNU GPL
-  v3.0], or [MPL v2.0]
+- Choose from several licenses, including [BSD-3], [MIT], [MPL v2.0], [Apache v2.0], [GNU GPL
+  v3.0], or [GNU LGPL v3.0]
 
 ## Requirements to Submit a Plugin
 
@@ -103,7 +106,7 @@ detailed description.
 
 ## License
 
-Distributed under the terms of the [MIT license], cookiecutter napari
+Distributed under the terms of the [BSD-3] license, cookiecutter napari
 plugin is free and open source software.
 
   [napari organization]: https://github.com/napari/
@@ -119,7 +122,6 @@ plugin is free and open source software.
   [tox]: https://tox.readthedocs.io/en/latest/
   [Submit a Plugin]: https://docs.napari.org/en/latest/contributing.html#submitting-plugins-to-napari
   [napari hook reference]: https://docs.napari.org/en/latest/writing_plugins.html#napari-hook-reference
-  [MIT license]: http://opensource.org/licenses/MIT
   [file an issue]: https://github.com/napari/cookiecutter-napari-plugin/issues
   [Sphinx]: http://sphinx-doc.org/
   [MkDocs]: http://www.mkdocs.org/
@@ -127,6 +129,7 @@ plugin is free and open source software.
   [MPL v2.0]: https://www.mozilla.org/media/MPL/2.0/index.txt
   [BSD-3]: http://opensource.org/licenses/BSD-3-Clause
   [GNU GPL v3.0]: http://www.gnu.org/licenses/gpl-3.0.txt
+  [GNU LGPL v3.0]: http://www.gnu.org/licenses/lgpl-3.0.txt
   [Apache v2.0]: http://www.apache.org/licenses/LICENSE-2.0
   [Travis CI]: https://travis-ci.com/
   [AppVeyor]: http://www.appveyor.com/

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -13,10 +13,11 @@
         "none"
     ],
     "license": [
-        "MIT",
         "BSD-3",
-        "GNU GPL v3.0",
+        "MIT",
+        "Mozilla Public License 2.0",
         "Apache Software License 2.0",
-        "Mozilla Public License 2.0"
+        "GNU LGPL v3.0",
+        "GNU GPL v3.0"
     ]
 }

--- a/napari-{{cookiecutter.plugin_name}}/LICENSE
+++ b/napari-{{cookiecutter.plugin_name}}/LICENSE
@@ -4,6 +4,8 @@
 {%- include 'licenses/BSD-3' %}
 {%- elif cookiecutter.license == "GNU GPL v3.0" -%}
 {%- include 'licenses/GPL-3' %}
+{%- elif cookiecutter.license == "GNU LGPL v3.0" -%}
+{%- include 'licenses/LGPL-3' %}
 {%- elif cookiecutter.license == "Apache Software License 2.0" -%}
 {%- include 'licenses/Apache-2' %}
 {%- elif cookiecutter.license == "Mozilla Public License 2.0" -%}

--- a/napari-{{cookiecutter.plugin_name}}/README.rst
+++ b/napari-{{cookiecutter.plugin_name}}/README.rst
@@ -58,7 +58,8 @@ the coverage at least stays the same before you submit a pull request.
 License
 -------
 
-Distributed under the terms of the `{{cookiecutter.license}}`_ license, "napari-{{cookiecutter.plugin_name}}" is free and open source software
+Distributed under the terms of the `{{cookiecutter.license}}`_ license,
+"napari-{{cookiecutter.plugin_name}}" is free and open source software
 
 
 Issues
@@ -71,7 +72,9 @@ If you encounter any problems, please `file an issue`_ along with a detailed des
 .. _`MIT`: http://opensource.org/licenses/MIT
 .. _`BSD-3`: http://opensource.org/licenses/BSD-3-Clause
 .. _`GNU GPL v3.0`: http://www.gnu.org/licenses/gpl-3.0.txt
+.. _`GNU LGPL v3.0`: http://www.gnu.org/licenses/lgpl-3.0.txt
 .. _`Apache Software License 2.0`: http://www.apache.org/licenses/LICENSE-2.0
+.. _`Mozilla Public License 2.0`: https://www.mozilla.org/media/MPL/2.0/index.txt
 .. _`cookiecutter-napari-plugin`: https://github.com/napari/cookiecutter-napari-plugin
 .. _`file an issue`: https://github.com/{{cookiecutter.github_username}}/napari-{{cookiecutter.plugin_name}}/issues
 .. _`napari`: https://github.com/napari/napari

--- a/napari-{{cookiecutter.plugin_name}}/licenses/LGPL-3
+++ b/napari-{{cookiecutter.plugin_name}}/licenses/LGPL-3
@@ -1,0 +1,166 @@
+{# source: http://www.gnu.org/licenses/lgpl-3.0.txt #}
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.


### PR DESCRIPTION
This will close #1 by
- making BSD-3 the default license for people using the cookiecutter
- changing the license of this repo itself from MIT to BSD-3
- adding LGPL as an option to the list, which now looks like this:
```
Select license:
1 - BSD-3
2 - MIT
3 - Mozilla Public License 2.0
4 - Apache Software License 2.0
5 - GNU LGPL v3.0
6 - GNU GPL v3.0
Choose from 1, 2, 3, 4, 5, 6 (1, 2, 3, 4, 5, 6) [1]:
```

(note: Mozilla and Apache were already in there, but the readme that @sofroniewn was presumably looking at in his original comment was not correct)

@jni, @sofroniewn, @AhmetCanSolak ... lemme know if you have any additional thoughts/ requests.