### PR TITLE
change underscores to hyphens for napari_plugin_engine

### DIFF
--- a/napari-{{cookiecutter.plugin_name}}/requirements.txt
+++ b/napari-{{cookiecutter.plugin_name}}/requirements.txt
@@ -1,2 +1,2 @@
-napari_plugin_engine>=0.1.4
+napari-plugin-engine>=0.1.4
 numpy


### PR DESCRIPTION
Having hyphens rather than underscores makes this requirements file compatible to use in conda recipes as well.
In fact this is exploiting some pip automagic. Underscores in module names are discouraged (pep8).

Quote from pep8:
> Modules should have short, all-lowercase names. Underscores can be used in the module name if it improves readability. Python packages should also have short, all-lowercase names, although the use of underscores is discouraged.