### PR TITLE
add git to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Minimal [Cookiecutter] template for authoring [napari] plugins.
 Install [Cookiecutter] and generate a new napari plugin project:
 
 ```bash
+conda install git
 pip install cookiecutter
 cookiecutter https://github.com/napari/cookiecutter-napari-plugin
 ```


### PR DESCRIPTION
closes #22 B-)

I guess power-users will realize that they don't have to install git and will just read over that line.