### PR TITLE
Migrate setup configuration to setup.cfg

### DIFF
--- a/{{cookiecutter.plugin_name}}/requirements.txt
+++ b/{{cookiecutter.plugin_name}}/requirements.txt
@@ -1,2 +1,1 @@
-napari-plugin-engine>=0.1.4
-numpy
+-e .

--- a/{{cookiecutter.plugin_name}}/setup.cfg
+++ b/{{cookiecutter.plugin_name}}/setup.cfg
@@ -1,0 +1,40 @@
+[metadata]
+name = {{cookiecutter.plugin_name}}
+author = {{cookiecutter.full_name}}
+author_email = {{cookiecutter.email}}
+license = {{cookiecutter.license}}
+url = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}
+description = {{cookiecutter.short_description}}
+long_description = file: README.md
+long_description_content_type = text/markdown
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    Framework :: napari
+    Topic :: Software Development :: Testing
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Operating System :: OS Independent
+    {% if cookiecutter.license == "MIT" -%}
+    License :: OSI Approved :: MIT License
+    {%- elif cookiecutter.license == "BSD-3" -%}
+    License :: OSI Approved :: BSD License
+    {%- elif cookiecutter.license == "GNU GPL v3.0" -%}
+    License :: OSI Approved :: GNU General Public License v3 (GPLv3)
+    {%- elif cookiecutter.license == "Apache Software License 2.0" -%}
+    License :: OSI Approved :: Apache Software License
+    {%- elif cookiecutter.license == "Mozilla Public License 2.0" -%}
+    License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)
+    {%- endif %}
+
+[options]
+packages = find:
+python_requires = >=3.6
+setup_requires = setuptools_scm
+
+[options.entry_points] 
+napari.plugin = 
+    {{cookiecutter.plugin_name}} = {{cookiecutter.module_name}}

--- a/{{cookiecutter.plugin_name}}/setup.cfg
+++ b/{{cookiecutter.plugin_name}}/setup.cfg
@@ -32,7 +32,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 setup_requires = setuptools_scm
 # add your minimal requirements here
 install_requires =

--- a/{{cookiecutter.plugin_name}}/setup.cfg
+++ b/{{cookiecutter.plugin_name}}/setup.cfg
@@ -34,6 +34,10 @@ classifiers =
 packages = find:
 python_requires = >=3.6
 setup_requires = setuptools_scm
+install_requires =
+    napari-plugin-engine>=0.1.4
+    numpy
+
 
 [options.entry_points] 
 napari.plugin = 

--- a/{{cookiecutter.plugin_name}}/setup.cfg
+++ b/{{cookiecutter.plugin_name}}/setup.cfg
@@ -34,6 +34,7 @@ classifiers =
 packages = find:
 python_requires = >=3.6
 setup_requires = setuptools_scm
+# add your minimal requirements here
 install_requires =
     napari-plugin-engine>=0.1.4
     numpy

--- a/{{cookiecutter.plugin_name}}/setup.cfg
+++ b/{{cookiecutter.plugin_name}}/setup.cfg
@@ -8,7 +8,7 @@ description = {{cookiecutter.short_description}}
 long_description = file: README.md
 long_description_content_type = text/markdown
 classifiers =
-    Development Status :: 4 - Beta
+    Development Status :: 2 - Pre-Alpha
     Intended Audience :: Developers
     Framework :: napari
     Topic :: Software Development :: Testing

--- a/{{cookiecutter.plugin_name}}/setup.cfg
+++ b/{{cookiecutter.plugin_name}}/setup.cfg
@@ -34,7 +34,7 @@ classifiers =
 packages = find:
 python_requires = >=3.7
 setup_requires = setuptools_scm
-# add your minimal requirements here
+# add your package requirements here
 install_requires =
     napari-plugin-engine>=0.1.4
     numpy

--- a/{{cookiecutter.plugin_name}}/setup.py
+++ b/{{cookiecutter.plugin_name}}/setup.py
@@ -2,16 +2,6 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup
 
-
-# Add your dependencies in requirements.txt
-# Note: you can add test-specific requirements in tox.ini
-requirements = []
-with open('requirements.txt') as f:
-    for line in f:
-        stripped = line.split("#")[0].strip()
-        if len(stripped) > 0:
-            requirements.append(stripped)
-
 {% if cookiecutter.plugin_name == "foo-bar" %}
 # extracted because it breaks testing of this cookiecutter template
 use_scm = False
@@ -20,6 +10,5 @@ use_scm = False
 use_scm = {"write_to": "{{cookiecutter.module_name}}/_version.py"}
 {% endif %}
 setup(
-    install_requires=requirements,
     use_scm_version=use_scm,
 )

--- a/{{cookiecutter.plugin_name}}/setup.py
+++ b/{{cookiecutter.plugin_name}}/setup.py
@@ -1,14 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-import os
-import codecs
-from setuptools import setup, find_packages
-
-
-def read(fname):
-    file_path = os.path.join(os.path.dirname(__file__), fname)
-    return codecs.open(file_path, encoding='utf-8').read()
+from setuptools import setup
 
 
 # Add your dependencies in requirements.txt
@@ -28,45 +20,6 @@ use_scm = False
 use_scm = {"write_to": "{{cookiecutter.module_name}}/_version.py"}
 {% endif %}
 setup(
-    name='{{cookiecutter.plugin_name}}',
-    author='{{cookiecutter.full_name}}',
-    author_email='{{cookiecutter.email}}',
-    license='{{cookiecutter.license}}',
-    url='https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}',
-    description='{{cookiecutter.short_description}}',
-    long_description=read('README.md'),
-    long_description_content_type='text/markdown',
-    packages=find_packages(),
-    python_requires='>=3.6',
     install_requires=requirements,
     use_scm_version=use_scm,
-    setup_requires=['setuptools_scm'],
-    classifiers=[
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: Developers',
-        'Framework :: napari',
-        'Topic :: Software Development :: Testing',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Operating System :: OS Independent',
-        {% if cookiecutter.license == "MIT" -%}
-        'License :: OSI Approved :: MIT License',
-        {%- elif cookiecutter.license == "BSD-3" -%}
-        'License :: OSI Approved :: BSD License',
-        {%- elif cookiecutter.license == "GNU GPL v3.0" -%}
-        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-        {%- elif cookiecutter.license == "Apache Software License 2.0" -%}
-        'License :: OSI Approved :: Apache Software License',
-        {%- elif cookiecutter.license == "Mozilla Public License 2.0" -%}
-        'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
-        {%- endif %}
-    ],
-    entry_points={
-        'napari.plugin': [
-            '{{cookiecutter.plugin_name}} = {{cookiecutter.module_name}}',
-        ],
-    },
 )


### PR DESCRIPTION
- Moved configuration options into `setup.cfg`.
- For editable installs, kept `use_scm` in `setup.py`.
-  `setup.cfg` doesn't support a `file:` option for the `install_requires` keyword, and it doesn't look like that'll be coming anytime soon, based on the discussion in [this issue](https://github.com/pypa/setuptools/issues/1951). So for our purposes I've kept the requirements reading in setup.py

I built a plugin locally and it worked as expected. I tried running tests locally but running the created plugin's tests failed with 
```python
E           TypeError: Failed expected string as 'msg' parameter, got 'CalledProcessError' instead.
E           Perhaps you meant to use a mark?
```

I saw the same behaviour on master though so I think it must be something I'm doing wrong.

Addresses #26.
