### PR TITLE
Add project url defaults

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -21,6 +21,5 @@
         "Apache Software License 2.0",
         "GNU LGPL v3.0",
         "GNU GPL v3.0"
-    ],
-    "twitter_handle": "none"
+    ]
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -22,5 +22,5 @@
         "GNU LGPL v3.0",
         "GNU GPL v3.0"
     ],
-    "include_project_url_defaults": "n"
+    "twitter_handle": "none"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -21,5 +21,6 @@
         "Apache Software License 2.0",
         "GNU LGPL v3.0",
         "GNU GPL v3.0"
-    ]
+    ],
+    "include_project_url_defaults": "n"
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -93,17 +93,15 @@ Your plugin template is ready!  Next steps:
 """
     )
 
-    {% if cookiecutter.include_project_url_defaults == "y" %}
     print("""
-5. You indicated you wanted defaults added for napari hub project URLs. The following default URLs have been added to `setup.cfg`:
+5. The following default URLs have been added to `setup.cfg`:
 
     Bug Tracker = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/issues
     Documentation = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/blob/master/README.md
     Source Code = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}
     User Support = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/issues
-    Twitter = https://twitter.com/{{cookiecutter.plugin_name}}
 
-These URLs will be displayed on your plugin's napari hub page. 
-You may wish to change these before publishing your plugin!
-    """)
-    {% endif %}
+    These URLs will be displayed on your plugin's napari hub page. 
+    You may wish to change these before publishing your plugin!
+"""
+    )

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -97,7 +97,7 @@ Your plugin template is ready!  Next steps:
 5. The following default URLs have been added to `setup.cfg`:
 
     Bug Tracker = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/issues
-    Documentation = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/blob/master/README.md
+    Documentation = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}#README.md
     Source Code = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}
     User Support = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/issues
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -92,3 +92,18 @@ Your plugin template is ready!  Next steps:
 4. Read the README for more info: https://github.com/napari/cookiecutter-napari-plugin
 """
     )
+
+    {% if cookiecutter.include_project_url_defaults == "y" %}
+    print("""
+5. You indicated you wanted defaults added for napari hub project URLs. The following default URLs have been added to `setup.cfg`:
+
+    Bug Tracker = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/issues
+    Documentation = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/blob/master/README.md
+    Source Code = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}
+    User Support = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/issues
+    Twitter = https://twitter.com/{{cookiecutter.plugin_name}}
+
+These URLs will be displayed on your plugin's napari hub page. 
+You may wish to change these before publishing your plugin!
+    """)
+    {% endif %}

--- a/{{cookiecutter.plugin_name}}/setup.cfg
+++ b/{{cookiecutter.plugin_name}}/setup.cfg
@@ -29,6 +29,14 @@ classifiers =
     {%- elif cookiecutter.license == "Mozilla Public License 2.0" -%}
     License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)
     {%- endif %}
+{% if cookiecutter.include_project_url_defaults == "y" -%}
+project_urls =
+    Bug Tracker = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/issues
+    Documentation = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/blob/master/README.md
+    Source Code = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}
+    User Support = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/issues
+    Twitter = https://twitter.com/{{cookiecutter.plugin_name}}
+{% endif %}
 
 [options]
 packages = find:

--- a/{{cookiecutter.plugin_name}}/setup.cfg
+++ b/{{cookiecutter.plugin_name}}/setup.cfg
@@ -29,13 +29,13 @@ classifiers =
     {%- elif cookiecutter.license == "Mozilla Public License 2.0" -%}
     License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)
     {%- endif %}
-{% if cookiecutter.include_project_url_defaults == "y" -%}
 project_urls =
     Bug Tracker = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/issues
     Documentation = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/blob/master/README.md
     Source Code = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}
     User Support = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/issues
-    Twitter = https://twitter.com/{{cookiecutter.plugin_name}}
+{% if cookiecutter.twitter_handle != "none" -%}
+    Twitter = https://twitter.com/{{cookiecutter.twitter_handle}}
 {% endif %}
 
 [options]

--- a/{{cookiecutter.plugin_name}}/setup.cfg
+++ b/{{cookiecutter.plugin_name}}/setup.cfg
@@ -31,12 +31,9 @@ classifiers =
     {%- endif %}
 project_urls =
     Bug Tracker = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/issues
-    Documentation = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/blob/master/README.md
+    Documentation = 'https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}#README.md'
     Source Code = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}
     User Support = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/issues
-{% if cookiecutter.twitter_handle != "none" -%}
-    Twitter = https://twitter.com/{{cookiecutter.twitter_handle}}
-{% endif %}
 
 [options]
 packages = find:


### PR DESCRIPTION
The missing napari hub metadata ended up being exclusively project URLs namely:

```
project_urls =
    Bug Tracker = ...
    Documentation = ...
    Source Code = ...
    User Support = ...
    Twitter = ...
 ```
 
Since conditional prompts are not supported by `cookiecutter` at the moment, we will provide sane defaults for the project URLs and alert the user that they've been added to setup.cfg.
 
The following defaults are used:
 
 ```
 project_urls =
    Bug Tracker = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/issues
    Documentation = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/blob/master/README.md
    Source Code = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}
    User Support = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/issues
```

The user is explicitly asked for a Twitter handle, and this entry is omitted if one is not provided.