### PR TITLE
fix tests for new make_napari_viewer fixture settings

### DIFF
--- a/{{cookiecutter.plugin_name}}/{{cookiecutter.module_name}}/_tests/test_dock_widget.py
+++ b/{{cookiecutter.plugin_name}}/{{cookiecutter.module_name}}/_tests/test_dock_widget.py
@@ -1,4 +1,4 @@
-from {{cookiecutter.module_name}} import napari_experimental_provide_dock_widget
+import {{cookiecutter.module_name}}
 import pytest
 
 # this is your plugin name declared in your napari.plugins entry point
@@ -8,7 +8,8 @@ MY_WIDGET_NAMES = ["Example Q Widget", "example_magic_widget"]
 
 
 @pytest.mark.parametrize("widget_name", MY_WIDGET_NAMES)
-def test_something_with_viewer(widget_name, make_napari_viewer):
+def test_something_with_viewer(widget_name, make_napari_viewer, napari_plugin_manager):
+    napari_plugin_manager.register({{cookiecutter.module_name}}, name=MY_PLUGIN_NAME)
     viewer = make_napari_viewer()
     num_dw = len(viewer.window._dock_widgets)
     viewer.window.add_plugin_dock_widget(

--- a/{{cookiecutter.plugin_name}}/{{cookiecutter.module_name}}/_tests/test_function.py
+++ b/{{cookiecutter.plugin_name}}/{{cookiecutter.module_name}}/_tests/test_function.py
@@ -1,3 +1,7 @@
 # from {{cookiecutter.module_name}} import threshold, image_arithmetic
 
 # add your tests here...
+
+
+def test_something():
+    pass

--- a/{{cookiecutter.plugin_name}}/{{cookiecutter.module_name}}/_tests/test_writer.py
+++ b/{{cookiecutter.plugin_name}}/{{cookiecutter.module_name}}/_tests/test_writer.py
@@ -1,3 +1,7 @@
 # from {{cookiecutter.module_name}} import napari_get_writer, napari_write_image
 
 # add your tests here...
+
+
+def test_something():
+    pass


### PR DESCRIPTION
make_napari_viewer now prevents plugin discovery by default (see https://github.com/napari/napari/pull/2715)

this PR updates the tests here to explicitly register plugin