### PR TITLE
Explicitly register plugin in test

### DIFF
--- a/{{cookiecutter.plugin_name}}/{{cookiecutter.module_name}}/_tests/test_dock_widget.py
+++ b/{{cookiecutter.plugin_name}}/{{cookiecutter.module_name}}/_tests/test_dock_widget.py
@@ -1,4 +1,4 @@
-from {{cookiecutter.module_name}} import napari_experimental_provide_dock_widget
+import {{cookiecutter.module_name}}
 import pytest
 
 # this is your plugin name declared in your napari.plugins entry point
@@ -8,7 +8,9 @@ MY_WIDGET_NAMES = ["Example Q Widget", "example_magic_widget"]
 
 
 @pytest.mark.parametrize("widget_name", MY_WIDGET_NAMES)
-def test_something_with_viewer(widget_name, make_napari_viewer):
+def test_something_with_viewer(widget_name, make_napari_viewer, napari_plugin_manager):
+    # make_napari_viewer block plugin discovery, so we must register it manually
+    napari_plugin_manager.register({{cookiecutter.module_name}}, name=MY_PLUGIN_NAME)
     viewer = make_napari_viewer()
     num_dw = len(viewer.window._dock_widgets)
     viewer.window.add_plugin_dock_widget(

--- a/{{cookiecutter.plugin_name}}/{{cookiecutter.module_name}}/_tests/test_reader.py
+++ b/{{cookiecutter.plugin_name}}/{{cookiecutter.module_name}}/_tests/test_reader.py
@@ -1,10 +1,13 @@
 import numpy as np
+import {{cookiecutter.module_name}}
 from {{cookiecutter.module_name}} import napari_get_reader
 
 
 # tmp_path is a pytest fixture
-def test_reader(tmp_path):
+def test_reader(tmp_path, napari_plugin_manager):
     """An example of how you might test your plugin."""
+    # make_napari_viewer block plugin discovery, so we must register it manually
+    napari_plugin_manager.register({{cookiecutter.module_name}}, name="{{cookiecutter.plugin_name}}")
 
     # write some fake data using your supported file format
     my_test_file = str(tmp_path / "myfile.npy")
@@ -26,5 +29,7 @@ def test_reader(tmp_path):
 
 
 def test_get_reader_pass():
+    # make_napari_viewer block plugin discovery, so we must register it manually
+    napari_plugin_manager.register({{cookiecutter.module_name}}, name="{{cookiecutter.plugin_name}}")
     reader = napari_get_reader("fake.file")
     assert reader is None


### PR DESCRIPTION
Napari recently changed the test fixtures to block plugin discovery. This PR adds a few line to tests that manually and explicitly register the plugin.