### PR TITLE
Add /.napari/DESCRIPTION.md to nudge developers on preferred format

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -103,5 +103,9 @@ Your plugin template is ready!  Next steps:
 
     These URLs will be displayed on your plugin's napari hub page. 
     You may wish to change these before publishing your plugin!
+
+6. Your plugin will be displayed on the napari hub once published. We've provided a template description
+   for your plugin page at `.napari/DESCRIPTION.md`. You'll likely want to edit this before you publish 
+   your plugin.
 """
     )

--- a/{{cookiecutter.plugin_name}}/.napari/DESCRIPTION.md
+++ b/{{cookiecutter.plugin_name}}/.napari/DESCRIPTION.md
@@ -1,0 +1,53 @@
+# Description
+
+This should be a detailed description of the background and context of your plugin,
+how it's meant to be used, and perhaps some brief examples.
+
+If you have videos or screenshots of your plugin in action, you should include them
+here as well, to make them front and center for new users. Wherever possible, you
+should use absolute links to these assets, so that we can easily display them 
+on the hub.
+
+# Who is This For?
+
+This section should describe the target audience for this plugin (what knowledge,
+skills and experience are assumed), as well as a description of the types of data
+supported by this plugin.
+
+Try to make the data description as explicit as possible, so that users know the
+format your plugin expects. This applies both to reader plugins reading file formats
+and to function/dock widget plugins accepting layers and/or layer data.
+
+If you know of researchers, groups or labs using your plugin, or if it has been cited
+anywhere, feel free to also include this information here.
+
+# How to Guide
+
+This section should go through step-by-step examples of how your plugin should be used.
+Where your plugin provides multiple dock widgets or functions, you should split these
+out into separate subsections for easy browsing. Include screenshots and videos
+wherever possible to elucidate your descriptions. 
+
+Ideally, this section should start with minimal examples for those who just want a
+quick overview of the plugin's functionality, but this is also a good place to put
+more complex and in-depth tutorials highlighting any intricacies of your plugin.
+
+# Preparing for Installation (optional)
+
+Most plugins can be installed out-of-the-box by just specifying the package requirements
+over in `setup.cfg`. However, if your plugin has any more complex dependencies, or 
+requires any additional preparation before installation, you should add this information
+here.
+
+# Getting Help
+
+This section should point users to your preferred support tools, whether this be raising
+an issue on GitHub, asking a question on image.sc, or using some other method of contact.
+If you distinguish between usage support and bug/feature support, you should state that
+here.
+
+# How to Cite
+
+Many plugins may be used in the course of published (or publishable) research, as well as
+during conference talks and other public facing events. If you'd like to be cited in
+a particular format, or have a DOI you'd like used, you should provide that information here.

--- a/{{cookiecutter.plugin_name}}/.napari/DESCRIPTION.md
+++ b/{{cookiecutter.plugin_name}}/.napari/DESCRIPTION.md
@@ -15,21 +15,23 @@ If you have videos or screenshots of your plugin in action, you should include t
 here as well, to make them front and center for new users. 
 
 You should use absolute links to these assets, so that we can easily display them 
-on the hub. You can include videos using the Share-Embed
-option on a YouTube video e.g.
+on the hub. The easiest way to include a video is to use a GIF, for example hosted
+on imgur. You can then reference this GIF as an image.
 
-```html
-<iframe width="560" height="315" 
-  src="https://www.youtube.com/embed/VXdFOcBCto4" 
-  title="YouTube video player" 
-  frameborder="0" 
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
-  allowfullscreen>
-</iframe>
-```
+![Example GIF hosted on Imgur](https://i.imgur.com/QD4fAWt.gif)
 
-Note that you won't be able to see the video rendered in markdown - it will be
-rendered when we pull this content for the hub.
+The other alternative, if you prefer to keep a video, is to use GitHub's video
+embedding feature.
+
+1. Push your `DESCRIPTION.md` to GitHub on your repository (this can also be done
+as part of a Pull Request)
+2. Edit `.napari/DESCRIPTION.md` **on GitHub**.
+3. Drag and drop your video into its desired location. It will be uploaded and
+hosted on GitHub for you, but will not be placed in your repository.
+4. We will take the resolved link to the video and render it on the hub.
+
+Here is an example of an mp4 video embedded this way.
+
 
 # Intended Audience & Supported Data
 

--- a/{{cookiecutter.plugin_name}}/.napari/DESCRIPTION.md
+++ b/{{cookiecutter.plugin_name}}/.napari/DESCRIPTION.md
@@ -1,12 +1,32 @@
 # Description
 
-This should be a detailed description of the background and context of your plugin,
+This should be a detailed description of the context of your plugin,
 how it's meant to be used, and perhaps some brief examples.
 
 If you have videos or screenshots of your plugin in action, you should include them
-here as well, to make them front and center for new users. Wherever possible, you
-should use absolute links to these assets, so that we can easily display them 
-on the hub.
+here as well, to make them front and center for new users. 
+
+You should use absolute links to these assets, so that we can easily display them 
+on the hub. You can include videos using the Share-Embed
+option on a YouTube video e.g.
+
+```html
+<iframe width="560" height="315" 
+  src="https://www.youtube.com/embed/VXdFOcBCto4" 
+  title="YouTube video player" 
+  frameborder="0" 
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
+  allowfullscreen>
+</iframe>
+```
+<iframe width="560" height="315" 
+  src="https://www.youtube.com/embed/VXdFOcBCto4" 
+  title="YouTube video player" 
+  frameborder="0" 
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
+  allowfullscreen>
+</iframe>
+
 
 # Who is This For?
 

--- a/{{cookiecutter.plugin_name}}/.napari/DESCRIPTION.md
+++ b/{{cookiecutter.plugin_name}}/.napari/DESCRIPTION.md
@@ -1,3 +1,5 @@
+
+
 <!-- This file is designed to provide you with a starting template for documenting
 the functionality of your plugin. Its content will be rendered on your plugin's
 napari hub page.
@@ -32,6 +34,7 @@ hosted on GitHub for you, but will not be placed in your repository.
 
 Here is an example of an mp4 video embedded this way.
 
+https://user-images.githubusercontent.com/17995243/120088305-6c093380-c132-11eb-822d-620e81eb5f0e.mp4
 
 # Intended Audience & Supported Data
 

--- a/{{cookiecutter.plugin_name}}/.napari/DESCRIPTION.md
+++ b/{{cookiecutter.plugin_name}}/.napari/DESCRIPTION.md
@@ -6,7 +6,7 @@ napari hub page.
 
 The sections below are given as a guide for the flow of information only, and
 are in no way prescriptive. You should feel free to merge, remove, add and 
-rename sections at will to make this document work best for your plugin. -->
+rename sections at will to make this document work best for your plugin. 
 
 # Description
 
@@ -66,7 +66,7 @@ quick overview of the plugin's functionality, but you should definitely link out
 more complex and in-depth tutorials highlighting any intricacies of your plugin, and
 more detailed documentation if you have it.
 
-<!-- # Additional Install Steps (uncommon)
+# Additional Install Steps (uncommon)
 We will be providing installation instructions on the hub, which will be sufficient
 for the majority of plugins. They will include instructions to pip install, and
 to install via napari itself.
@@ -74,7 +74,7 @@ to install via napari itself.
 Most plugins can be installed out-of-the-box by just specifying the package requirements
 over in `setup.cfg`. However, if your plugin has any more complex dependencies, or 
 requires any additional preparation before (or after) installation, you should add 
-this information here. -->
+this information here.
 
 # Getting Help
 
@@ -87,4 +87,6 @@ here.
 
 Many plugins may be used in the course of published (or publishable) research, as well as
 during conference talks and other public facing events. If you'd like to be cited in
-a particular format, or have a DOI you'd like used, you should provide that information here.
+a particular format, or have a DOI you'd like used, you should provide that information here. -->
+
+The developer has not yet provided a napari-hub specific description.

--- a/{{cookiecutter.plugin_name}}/.napari/DESCRIPTION.md
+++ b/{{cookiecutter.plugin_name}}/.napari/DESCRIPTION.md
@@ -1,7 +1,15 @@
+<!-- This file is designed to provide you with a starting template for documenting
+the functionality of your plugin. Its content will be rendered on your plugin's
+napari hub page.
+
+The sections below are given as a guide for the flow of information only, and
+are in no way prescriptive. You should feel free to merge, remove, add and 
+rename sections at will to make this document work best for your plugin. -->
+
 # Description
 
-This should be a detailed description of the context of your plugin,
-how it's meant to be used, and perhaps some brief examples.
+This should be a detailed description of the context of your plugin and its 
+intended purpose.
 
 If you have videos or screenshots of your plugin in action, you should include them
 here as well, to make them front and center for new users. 
@@ -19,29 +27,26 @@ option on a YouTube video e.g.
   allowfullscreen>
 </iframe>
 ```
-<iframe width="560" height="315" 
-  src="https://www.youtube.com/embed/VXdFOcBCto4" 
-  title="YouTube video player" 
-  frameborder="0" 
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
-  allowfullscreen>
-</iframe>
 
+Note that you won't be able to see the video rendered in markdown - it will be
+rendered when we pull this content for the hub.
 
-# Who is This For?
+# Intended Audience & Supported Data
 
-This section should describe the target audience for this plugin (what knowledge,
-skills and experience are assumed), as well as a description of the types of data
+This section should describe the target audience for this plugin (any knowledge,
+skills and experience required), as well as a description of the types of data
 supported by this plugin.
 
 Try to make the data description as explicit as possible, so that users know the
 format your plugin expects. This applies both to reader plugins reading file formats
 and to function/dock widget plugins accepting layers and/or layer data.
+For example, if you know your plugin only works with 3D integer data in "tyx" order,
+make sure to mention this.
 
 If you know of researchers, groups or labs using your plugin, or if it has been cited
 anywhere, feel free to also include this information here.
 
-# How to Guide
+# Quickstart
 
 This section should go through step-by-step examples of how your plugin should be used.
 Where your plugin provides multiple dock widgets or functions, you should split these
@@ -49,15 +54,19 @@ out into separate subsections for easy browsing. Include screenshots and videos
 wherever possible to elucidate your descriptions. 
 
 Ideally, this section should start with minimal examples for those who just want a
-quick overview of the plugin's functionality, but this is also a good place to put
-more complex and in-depth tutorials highlighting any intricacies of your plugin.
+quick overview of the plugin's functionality, but you should definitely link out to
+more complex and in-depth tutorials highlighting any intricacies of your plugin, and
+more detailed documentation if you have it.
 
-# Preparing for Installation (optional)
+<!-- # Additional Install Steps (uncommon)
+We will be providing installation instructions on the hub, which will be sufficient
+for the majority of plugins. They will include instructions to pip install, and
+to install via napari itself.
 
 Most plugins can be installed out-of-the-box by just specifying the package requirements
 over in `setup.cfg`. However, if your plugin has any more complex dependencies, or 
-requires any additional preparation before installation, you should add this information
-here.
+requires any additional preparation before (or after) installation, you should add 
+this information here. -->
 
 # Getting Help
 

--- a/{{cookiecutter.plugin_name}}/.napari/DESCRIPTION.md
+++ b/{{cookiecutter.plugin_name}}/.napari/DESCRIPTION.md
@@ -20,7 +20,10 @@ You should use absolute links to these assets, so that we can easily display the
 on the hub. The easiest way to include a video is to use a GIF, for example hosted
 on imgur. You can then reference this GIF as an image.
 
-![Example GIF hosted on Imgur](https://i.imgur.com/QD4fAWt.gif)
+![Example GIF hosted on Imgur](https://i.imgur.com/A5phCX4.gif)
+
+Note that GIFs larger than 5MB won't be rendered by GitHub - we will however,
+render them on the napari hub.
 
 The other alternative, if you prefer to keep a video, is to use GitHub's video
 embedding feature.


### PR DESCRIPTION
To keep the repository README and napari hub documentation separate, this PR adds a `.napari/DESCRIPTION.md` file ~(still need to add prompts for it) to show users the preferred format for documentation on the hub.~ with prompts for developers on information flow and the sections they could use. 

Also add message after generation to point users to this file.