### PR TITLE
Add spdx identifiers for licenses

### DIFF
--- a/{{cookiecutter.plugin_name}}/setup.cfg
+++ b/{{cookiecutter.plugin_name}}/setup.cfg
@@ -5,7 +5,19 @@ version = 0.0.1
 {%- endif %}
 author = {{cookiecutter.full_name}}
 author_email = {{cookiecutter.email}}
+{% if cookiecutter.license == "MIT" -%}
 license = {{cookiecutter.license}}
+{%- elif cookiecutter.license == "BSD-3" -%}
+license = BSD-3-Clause
+{%- elif cookiecutter.license == "GNU GPL v3.0" -%}
+license = GPL-3.0-only
+{%- elif cookiecutter.license == "GNU LGPL v3.0" -%}
+license = LGPL-3.0-only
+{%- elif cookiecutter.license == "Apache Software License 2.0" -%}
+license = Apache-2.0
+{%- elif cookiecutter.license == "Mozilla Public License 2.0" -%}
+license = MPL-2.0
+{%- endif %}
 url = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}
 description = {{cookiecutter.short_description}}
 long_description = file: README.md
@@ -27,6 +39,8 @@ classifiers =
     License :: OSI Approved :: BSD License
     {%- elif cookiecutter.license == "GNU GPL v3.0" -%}
     License :: OSI Approved :: GNU General Public License v3 (GPLv3)
+    {%- elif cookiecutter.license == "GNU LGPL v3.0" -%}
+    License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)
     {%- elif cookiecutter.license == "Apache Software License 2.0" -%}
     License :: OSI Approved :: Apache Software License
     {%- elif cookiecutter.license == "Mozilla Public License 2.0" -%}


### PR DESCRIPTION
On the napari hub only plugins with valid SPDX identifiers are displayed when filtering to only open source licenses.

This PR updates `setup.cfg` to use valid identifiers for all license choices we provide.
I also noticed we weren't adding the classifier for LGPL so I've added that too. 