### PR TITLE
Improve guessing and prompting for project URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Cookiecutter prompts you for information regarding your plugin
 ```bash
 full_name [Napari Developer]: Ramon y Cajal
 email [yourname@example.com]: ramon@cajal.es
-github_username [githubuser]: neuronz52
+github_username_or_organization [githubuser]: neuronz52
 # NOTE: for packages whose primary purpose is to be a napari plugin, we
 # recommend using the 'napari-' prefix in the package name.
 # If your package provides functionality outside of napari, you may

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,8 +1,9 @@
 {
     "full_name": "Napari Developer",
     "email": "yourname@example.com",
-    "github_username": "githubuser",
+    "github_username_or_organization": "githubuser",
     "plugin_name": "napari-foobar",
+    "github_repository_url": ["https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}}", "provide later"],
     "module_name": "{{ cookiecutter.plugin_name|lower|replace('-', '_') }}",
     "short_description": "A simple plugin to use with napari",
     "include_reader_plugin": "y",

--- a/docs/user-guide/quickstart.md
+++ b/docs/user-guide/quickstart.md
@@ -36,7 +36,7 @@ Cookiecutter prompts you for information regarding your plugin based on aforemen
 ```no-highlight
 full_name [Napari Developer]: Ramon y Cajal
 email [yourname@example.com]: ramon@cajal.es
-github_username [githubuser]: neuronz52
+github_username_or_organization [githubuser]: neuronz52
 plugin_name [napari-foobar]: growth-cone-finder
 module_name [growth_cone_finder]: growth_cone_finder
 short_description [A simple plugin to use with napari]:

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -79,29 +79,57 @@ Your plugin template is ready!  Next steps:
      git commit -m 'initial commit'
 
      # you probably want to install your new package into your env
-     pip install -e .
-
+     pip install -e ."""
+     )
+{% if cookiecutter.github_repository_url != 'provide later' %}
+    print("""
 2. Create a github repository with the name '{{ cookiecutter.plugin_name }}':
    https://github.com/new
 
 3. Add your newly created github repo as a remote and push:
 
-     git remote add origin https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.plugin_name }}.git
+     git remote add origin https://github.com/{{ cookiecutter.github_username_or_organization }}/{{ cookiecutter.plugin_name }}.git
      git push -u origin main
 
-4. Read the README for more info: https://github.com/napari/cookiecutter-napari-plugin
-"""
-    )
+4. The following default URLs have been added to `setup.cfg`:
 
-    print("""
-5. The following default URLs have been added to `setup.cfg`:
-
-    Bug Tracker = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/issues
-    Documentation = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}#README.md
-    Source Code = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}
-    User Support = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/issues
+    Bug Tracker = https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}}/issues
+    Documentation = https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}}#README.md
+    Source Code = https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}}
+    User Support = https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}}/issues
 
     These URLs will be displayed on your plugin's napari hub page. 
-    You may wish to change these before publishing your plugin!
+    You may wish to change these before publishing your plugin!"""
+    )
+{% else %}
+    print("""
+2. Create a github repository for your plugin:
+   https://github.com/new
+
+3. Add your newly created github repo as a remote and push:
+
+     git remote add origin https://github.com/your-repo-username/your-repo-name.git
+     git push -u origin main
+
+   Don't forget to add this url to setup.cfg!
+
+     [metadata]
+     url = https://github.com/your-repo-username/your-repo-name.git
+
+4. Consider adding additional links for documentation and user support to setup.cfg using the project_urls key e.g.
+    
+    [metadata]
+    project_urls =
+        Bug Tracker = https://github.com/your-repo-username/your-repo-name/issues
+        Documentation = https://github.com/your-repo-username/your-repo-name#README.md
+        Source Code = https://github.com/your-repo-username/your-repo-name
+        User Support = https://github.com/your-repo-username/your-repo-name/issues"""
+    )
+{% endif %}
+    print("""
+5. Read the README for more info: https://github.com/napari/cookiecutter-napari-plugin
+
+6. Consider customizing your plugin metadata for display on the napari hub: 
+   https://github.com/chanzuckerberg/napari-hub/blob/main/docs/customizing-plugin-listing.md
 """
     )

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -116,7 +116,8 @@ Your plugin template is ready!  Next steps:
      [metadata]
      url = https://github.com/your-repo-username/your-repo-name.git
 
-4. Consider adding additional links for documentation and user support to setup.cfg using the project_urls key e.g.
+4. Consider adding additional links for documentation and user support to setup.cfg 
+   using the project_urls key e.g.
     
     [metadata]
     project_urls =

--- a/{{cookiecutter.plugin_name}}/README.md
+++ b/{{cookiecutter.plugin_name}}/README.md
@@ -1,10 +1,10 @@
 # {{cookiecutter.plugin_name}}
 
-[![License](https://img.shields.io/pypi/l/{{cookiecutter.plugin_name}}.svg?color=green)](https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/raw/master/LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/{{cookiecutter.plugin_name}}.svg?color=green)](https://pypi.org/project/{{cookiecutter.plugin_name}})
 [![Python Version](https://img.shields.io/pypi/pyversions/{{cookiecutter.plugin_name}}.svg?color=green)](https://python.org)
-[![tests](https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/workflows/tests/badge.svg)](https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/actions)
-[![codecov](https://codecov.io/gh/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/branch/master/graph/badge.svg)](https://codecov.io/gh/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}})
+[![License](https://img.shields.io/pypi/l/{{cookiecutter.plugin_name}}.svg?color=green)](https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}}/raw/master/LICENSE)
+[![tests](https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}}/workflows/tests/badge.svg)](https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}}/actions)
+[![codecov](https://codecov.io/gh/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}}/branch/master/graph/badge.svg)](https://codecov.io/gh/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}})
 
 {{cookiecutter.short_description}}
 
@@ -50,7 +50,9 @@ If you encounter any problems, please [file an issue] along with a detailed desc
 [Apache Software License 2.0]: http://www.apache.org/licenses/LICENSE-2.0
 [Mozilla Public License 2.0]: https://www.mozilla.org/media/MPL/2.0/index.txt
 [cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin
-[file an issue]: https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/issues
+{% if cookiecutter.github_repository_url != 'provide later' %}
+[file an issue]: https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}}/issues
+{% endif %}
 [napari]: https://github.com/napari/napari
 [tox]: https://tox.readthedocs.io/en/latest/
 [pip]: https://pypi.org/project/pip/

--- a/{{cookiecutter.plugin_name}}/README.md
+++ b/{{cookiecutter.plugin_name}}/README.md
@@ -1,4 +1,5 @@
 # {{cookiecutter.plugin_name}}
+
 [![License](https://img.shields.io/pypi/l/{{cookiecutter.plugin_name}}.svg?color=green)](https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}}/raw/master/LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/{{cookiecutter.plugin_name}}.svg?color=green)](https://pypi.org/project/{{cookiecutter.plugin_name}})
 [![Python Version](https://img.shields.io/pypi/pyversions/{{cookiecutter.plugin_name}}.svg?color=green)](https://python.org)

--- a/{{cookiecutter.plugin_name}}/README.md
+++ b/{{cookiecutter.plugin_name}}/README.md
@@ -1,8 +1,7 @@
 # {{cookiecutter.plugin_name}}
-
+[![License](https://img.shields.io/pypi/l/{{cookiecutter.plugin_name}}.svg?color=green)](https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}}/raw/master/LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/{{cookiecutter.plugin_name}}.svg?color=green)](https://pypi.org/project/{{cookiecutter.plugin_name}})
 [![Python Version](https://img.shields.io/pypi/pyversions/{{cookiecutter.plugin_name}}.svg?color=green)](https://python.org)
-[![License](https://img.shields.io/pypi/l/{{cookiecutter.plugin_name}}.svg?color=green)](https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}}/raw/master/LICENSE)
 [![tests](https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}}/workflows/tests/badge.svg)](https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}}/actions)
 [![codecov](https://codecov.io/gh/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}}/branch/master/graph/badge.svg)](https://codecov.io/gh/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}})
 

--- a/{{cookiecutter.plugin_name}}/docs_sources/mkdocs/mkdocs.yml
+++ b/{{cookiecutter.plugin_name}}/docs_sources/mkdocs/mkdocs.yml
@@ -4,7 +4,8 @@ site_author: {{cookiecutter.full_name}}
 
 theme: readthedocs
 
-repo_url: https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}
-
+{% if cookiecutter.github_repository_url != 'provide later' %}
+repo_url: https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}}
+{% endif %}
 pages:
 - Home: index.md

--- a/{{cookiecutter.plugin_name}}/setup.cfg
+++ b/{{cookiecutter.plugin_name}}/setup.cfg
@@ -6,7 +6,9 @@ version = 0.0.1
 author = {{cookiecutter.full_name}}
 author_email = {{cookiecutter.email}}
 license = {{cookiecutter.license}}
-url = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}
+{% if cookiecutter.github_repository_url != 'provide later' -%}
+url = cookiecutter.github_repository_url
+{%- endif %}
 description = {{cookiecutter.short_description}}
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -32,11 +34,13 @@ classifiers =
     {%- elif cookiecutter.license == "Mozilla Public License 2.0" -%}
     License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)
     {%- endif %}
+{% if cookiecutter.github_repository_url != 'provide later' -%}
 project_urls =
-    Bug Tracker = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/issues
-    Documentation = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}#README.md
-    Source Code = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}
-    User Support = https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}/issues
+    Bug Tracker = https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}}/issues
+    Documentation = https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}}#README.md
+    Source Code = https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}}
+    User Support = https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}}/issues
+{%- endif %}
 
 [options]
 packages = find:

--- a/{{cookiecutter.plugin_name}}/setup.cfg
+++ b/{{cookiecutter.plugin_name}}/setup.cfg
@@ -7,7 +7,7 @@ author = {{cookiecutter.full_name}}
 author_email = {{cookiecutter.email}}
 license = {{cookiecutter.license}}
 {% if cookiecutter.github_repository_url != 'provide later' -%}
-url = cookiecutter.github_repository_url
+url = {{ cookiecutter.github_repository_url }}
 {%- endif %}
 description = {{cookiecutter.short_description}}
 long_description = file: README.md


### PR DESCRIPTION
Currently we guess that the github repository for a new plugin will be 
`https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}`

This is great most of the time, but can be problematic when the developer chooses to store the repository elsewhere e.g. within an organization. Because we silently add this link to `setup.cfg`, we risk links 404ing on PyPI and the napari hub - which is worse than them just not being provided.

This PR adds some extra logic around the URLs:
1. change the prompt to `github_username_or_organization` to make it clearer what the purpose of this question is (hopefully) 
2. add a question that allows the user to select the guessed url or `provide later`
3. If the user chooses `provide later`, don't add this url to `setup.cfg` or to `mkdocs.yml` to avoid 404s, and also exclude the `project_urls` defaults. I've chosen to leave this url on the readme badges, because it's very easy to notice if those links don't resolve and it also gives the user an indication of what they should put there to make it work.
4. Display information after project generation relevant to what the user chose

Feedback welcome on making this as clear and useful as possible.