### PR TITLE
add napari to dependencies

### DIFF
--- a/{{cookiecutter.plugin_name}}/setup.cfg
+++ b/{{cookiecutter.plugin_name}}/setup.cfg
@@ -61,6 +61,7 @@ setup_requires = setuptools_scm
 # add your package requirements here
 install_requires =
     napari-plugin-engine>=0.1.4
+    napari
     numpy
 
 


### PR DESCRIPTION
Hi all,

I'm adding `napari` again and again to this file in napari-plugins I make. I'm suggesting to make `napari` a dependency of all napari-plugins generated with the cookie-cutter. Is there a scenario where this dependency makes no sense?

Best,
Robert