### PR TITLE
Add napari hub badge to README

### DIFF
--- a/{{cookiecutter.plugin_name}}/README.md
+++ b/{{cookiecutter.plugin_name}}/README.md
@@ -5,6 +5,7 @@
 [![Python Version](https://img.shields.io/pypi/pyversions/{{cookiecutter.plugin_name}}.svg?color=green)](https://python.org)
 [![tests](https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}}/workflows/tests/badge.svg)](https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}}/actions)
 [![codecov](https://codecov.io/gh/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}}/branch/master/graph/badge.svg)](https://codecov.io/gh/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}})
+[![napari hub](https://img.shields.io/endpoint?url=https://api.napari-hub.org/shields/{{cookiecutter.plugin_name}})](https://napari-hub.org/plugins/{{cookiecutter.plugin_name}})
 
 {{cookiecutter.short_description}}
 


### PR DESCRIPTION
The napari hub API now offers the option for devs to add shields for their plugin linking back to the hub.

This PR adds this shield to the README.

Right now, before the plugin is published, users will see this:
![2021-09-17_10-30](https://user-images.githubusercontent.com/17995243/133705324-9b683f3e-e53f-425a-bcb4-0bbc82ff62f6.png)

This has been fixed over on the hub, and after release next week, users will see this instead:
![2021-09-17_10-36](https://user-images.githubusercontent.com/17995243/133705658-3ba150d4-284c-420a-bc2b-7799fe1bc6d6.png)

We can wait until release to merge this, if people are happy.
