### PR TITLE
Add information about installing plugin without manual clone

### DIFF
--- a/{{cookiecutter.plugin_name}}/README.md
+++ b/{{cookiecutter.plugin_name}}/README.md
@@ -26,6 +26,14 @@ You can install `{{cookiecutter.plugin_name}}` via [pip]:
 
     pip install {{cookiecutter.plugin_name}}
 
+
+{% if cookiecutter.github_repository_url != 'provide later' %}
+To install latest development version :
+
+    pip install git+https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}}.git
+
+{% endif %}
+
 ## Contributing
 
 Contributions are very welcome. Tests can be run with [tox], please ensure

--- a/{{cookiecutter.plugin_name}}/README.md
+++ b/{{cookiecutter.plugin_name}}/README.md
@@ -31,7 +31,6 @@ You can install `{{cookiecutter.plugin_name}}` via [pip]:
 To install latest development version :
 
     pip install git+https://github.com/{{cookiecutter.github_username_or_organization}}/{{cookiecutter.plugin_name}}.git
-
 {% endif %}
 
 ## Contributing


### PR DESCRIPTION
Add information about options to install from the repository without cloning  

```
pip install git+...
```

like 
```pip install git+https://github.com/sofroniewn/napari-animation.git```
