### PR TITLE
include src in setup.py

### DIFF
--- a/{{cookiecutter.plugin_name}}/setup.py
+++ b/{{cookiecutter.plugin_name}}/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 use_scm = False
 {% else %}
 # https://github.com/pypa/setuptools_scm
-use_scm = {"write_to": "{{cookiecutter.module_name}}/_version.py"}
+use_scm = {"write_to": "src/{{cookiecutter.module_name}}/_version.py"}
 {%- endif %}
 setup(use_scm_version=use_scm)
 {%- else -%}


### PR DESCRIPTION
editable installs with pip were failing because of the path change, this PR fixes that - we should probably add a test but I'm not sure of the best way to test that

```sh
(napari-filament-tracer) dbarford-mac-11.lmb.internal ➜  napari-filament-tracer git:(main) ✗  pip install -e .
Obtaining file:///Users/aburt/Programming/napari-filament-tracer
  Preparing metadata (setup.py) ... error
  ERROR: Command errored out with exit status 1:
   command: /Users/aburt/mambaforge/envs/napari-filament-tracer/bin/python3.9 -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/Users/aburt/Programming/napari-filament-tracer/setup.py'"'"'; __file__='"'"'/Users/aburt/Programming/napari-filament-tracer/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/0k/5yzjc0b956vfsgbl7ywtllsm0000gp/T/pip-pip-egg-info-jx6jy548
       cwd: /Users/aburt/Programming/napari-filament-tracer/
  Complete output (23 lines):
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/Users/aburt/Programming/napari-filament-tracer/setup.py", line 8, in <module>
      setup(use_scm_version=use_scm)
    File "/Users/aburt/mambaforge/envs/napari-filament-tracer/lib/python3.9/site-packages/setuptools/__init__.py", line 153, in setup
      return distutils.core.setup(**attrs)
    File "/Users/aburt/mambaforge/envs/napari-filament-tracer/lib/python3.9/distutils/core.py", line 108, in setup
      _setup_distribution = dist = klass(attrs)
    File "/Users/aburt/mambaforge/envs/napari-filament-tracer/lib/python3.9/site-packages/setuptools/dist.py", line 453, in __init__
      _Distribution.__init__(
    File "/Users/aburt/mambaforge/envs/napari-filament-tracer/lib/python3.9/distutils/dist.py", line 292, in __init__
      self.finalize_options()
    File "/Users/aburt/mambaforge/envs/napari-filament-tracer/lib/python3.9/site-packages/setuptools/dist.py", line 831, in finalize_options
      ep(self)
    File "/Users/aburt/mambaforge/envs/napari-filament-tracer/lib/python3.9/site-packages/setuptools/dist.py", line 852, in _finalize_setup_keywords
      ep.load()(self, ep.name, value)
    File "/Users/aburt/Programming/napari-filament-tracer/.eggs/setuptools_scm-6.3.2-py3.9.egg/setuptools_scm/integration.py", line 65, in version_keyword
      dist.metadata.version = _get_version(config)
    File "/Users/aburt/Programming/napari-filament-tracer/.eggs/setuptools_scm-6.3.2-py3.9.egg/setuptools_scm/__init__.py", line 185, in _get_version
      dump_version(
    File "/Users/aburt/Programming/napari-filament-tracer/.eggs/setuptools_scm-6.3.2-py3.9.egg/setuptools_scm/__init__.py", line 97, in dump_version
      with open(target, "w") as fp:
  FileNotFoundError: [Errno 2] No such file or directory: 'napari_filament_tracer/_version.py'

```