### PR TITLE
Updated .gitignore to reflect new path of `_version.py`

### DIFF
--- a/{{cookiecutter.plugin_name}}/.gitignore
+++ b/{{cookiecutter.plugin_name}}/.gitignore
@@ -76,4 +76,5 @@ target/
 .DS_Store
 
 # written by setuptools_scm
-*/_version.py
+**/_version.py
+


### PR DESCRIPTION
This fixes the `_version.py` ignore with the recent inclusion of the `src` directory.