### PR TITLE
updates Codecov Uploader to v2

### DIFF
--- a/{{cookiecutter.plugin_name}}/.github/workflows/test_and_deploy.yml
+++ b/{{cookiecutter.plugin_name}}/.github/workflows/test_and_deploy.yml
@@ -65,7 +65,7 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
 
       - name: Coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
 
   deploy:
     # this will run when you have tagged a commit, starting with "v*"


### PR DESCRIPTION
v1 uploader will be deprecated Feb 1, 2022

see https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1