### PR TITLE
add pre-commit config

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,23 @@ pytest  # run test in current environment
 If you chose to create docs with your plugin read the corresponding docs
 for [Sphinx] or [MkDocs]
 
+### Pre-commit
+
+This template includes a default yaml configuration for [pre-commit](https://pre-commit.com/).
+Among other things, it includes checks for best practices in napari plugins.
+You may edit the config at `.pre-commit-config.yaml`
+
+To use it run:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+You can also have these checks run automatically for you when you push to github
+by installing [pre-commit ci](https://pre-commit.ci/) on your repository.
+
+
 ## Features
 
 - Installable [PyPI] package featuring a `setup.py`

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -11,6 +11,7 @@
     "include_dock_widget_plugin": "y",
     "include_function_plugin": "y",
     "use_git_tags_for_versioning": "n",
+    "install_precommit": "n",
     "docs_tool": [
         "mkdocs",
         "sphinx",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -68,6 +68,7 @@ if __name__ == "__main__":
     remove_temp_folders(ALL_TEMP_FOLDERS)
     remove_unrequested_plugin_examples()
 
+    msg = ''
     # try to run git init
     try:
         subprocess.run(["git", "init", "-q"])
@@ -75,7 +76,7 @@ if __name__ == "__main__":
         subprocess.run(["git", "add", "."])
         subprocess.run(["git", "commit", "-q", "-m", "initial commit"])
     except Exception:
-        print("""
+        msg += """
 Your plugin template is ready!  Next steps:
 
 1. `cd` into your new directory and initialize a git repo
@@ -87,19 +88,19 @@ Your plugin template is ready!  Next steps:
      git commit -m 'initial commit'
 
      # you probably want to install your new package into your environment
-     pip install -e .""")
+     pip install -e ."""
     else:
-        print("""
+        msg +="""
 Your plugin template is ready!  Next steps:
 
 1. `cd` into your new directory
 
      cd {{ cookiecutter.plugin_name }}
      # you probably want to install your new package into your env
-     pip install -e .""")
+     pip install -e ."""
 
 {% if cookiecutter.github_repository_url != 'provide later' %}
-    print("""
+    msg += """
 2. Create a github repository with the name '{{ cookiecutter.plugin_name }}':
    https://github.com/new
 
@@ -117,9 +118,9 @@ Your plugin template is ready!  Next steps:
 
     These URLs will be displayed on your plugin's napari hub page. 
     You may wish to change these before publishing your plugin!"""
-    )
+    
 {% else %}
-    print("""
+    msg += """
 2. Create a github repository for your plugin:
    https://github.com/new
 
@@ -142,9 +143,8 @@ Your plugin template is ready!  Next steps:
         Documentation = https://github.com/your-repo-username/your-repo-name#README.md
         Source Code = https://github.com/your-repo-username/your-repo-name
         User Support = https://github.com/your-repo-username/your-repo-name/issues"""
-    )
 {% endif %}
-    print("""
+    msg += """
 5. Read the README for more info: https://github.com/napari/cookiecutter-napari-plugin
 
 6. We've provided a template description for your plugin page at `.napari/DESCRIPTION.md`. 
@@ -153,4 +153,17 @@ Your plugin template is ready!  Next steps:
 7. Consider customizing the rest of your plugin metadata for display on the napari hub: 
    https://github.com/chanzuckerberg/napari-hub/blob/main/docs/customizing-plugin-listing.md
 """
-    )
+
+{% if cookiecutter.github_repository_url == 'y' %}
+    # try to install and update pre-commit
+    try:
+        print("install pre-commit ...")
+        subprocess.run(["pip", "install", "pre-commit"], stdout=subprocess.DEVNULL)
+        print("updating pre-commit...")
+        subprocess.run(["pre-commit", "autoupdate"], stdout=subprocess.DEVNULL)
+        subprocess.run(["pre-commit", "install"])
+    except Exception:
+        pass
+{% endif %}
+
+    print(msg)

--- a/{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
@@ -1,0 +1,43 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: check-docstring-first
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/asottile/setup-cfg-fmt
+    rev: v1.20.0
+    hooks:
+      - id: setup-cfg-fmt
+  - repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-typing-imports==1.7.0]
+  - repo: https://github.com/myint/autoflake
+    rev: v1.4
+    hooks:
+      - id: autoflake
+        args: ["--in-place", "--remove-all-unused-imports"]
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+  - repo: https://github.com/psf/black
+    rev: 21.11b1
+    hooks:
+      - id: black
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.29.1
+    hooks:
+      - id: pyupgrade
+        args: [--py37-plus, --keep-runtime-typing]
+  - repo: https://github.com/tlambert03/napari-plugin-checks
+    rev: v0.2.0
+    hooks:
+      - id: napari-plugin-checks
+  # you may wish to add this as well!
+  # - repo: https://github.com/pre-commit/mirrors-mypy
+  #   rev: v0.910-1
+  #   hooks:
+  #     - id: mypy

--- a/{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
@@ -36,6 +36,7 @@ repos:
     rev: v0.2.0
     hooks:
       - id: napari-plugin-checks
+  # https://mypy.readthedocs.io/en/stable/introduction.html
   # you may wish to add this as well!
   # - repo: https://github.com/pre-commit/mirrors-mypy
   #   rev: v0.910-1


### PR DESCRIPTION
This adds a pre-commit config.  By default, it is not installed (the user still needs to run `pre-commit install`, but there is an option to install it, which will also auto-update the versions of the packages).

This includes the napari-specific "health checks" at https://github.com/tlambert03/napari-plugin-checks

closes #62