### PR TITLE
Minor edits to npe2 cookiecutter docs

### DIFF
--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -160,6 +160,8 @@ This prompt allows you to choose from a variety of open source licensing options
 for your plugin. Choosing any of the options will lead to a boilerplate `LICENSE`
 file being added to the root of your plugin directory, as well as the [SPDX identifier](https://spdx.org/licenses/)
 for that license being listed in your `setup.cfg` under the `license` field.
+License options include: [BSD-3], [MIT], [MPL v2.0], [Apachev2.0], [GNU GPL v3.0], or [GNU LGPL v3.0]
+
 
 [spec]: https://napari.org/plugins/stable/npe2_manifest_specification.html
 [reader-spec]: https://napari.org/plugins/stable/npe2_manifest_specification.html#readers
@@ -168,3 +170,9 @@ for that license being listed in your `setup.cfg` under the `license` field.
 [widget-spec]: https://napari.org/plugins/stable/npe2_manifest_specification.html#widgets-experimental
 [sample-data-spec]: https://napari.org/plugins/stable/npe2_manifest_specification.html
 [glob pattern]: https://en.wikipedia.org/wiki/Glob_(programming)
+[mit]: http://opensource.org/licenses/MIT
+[mpl v2.0]: https://www.mozilla.org/media/MPL/2.0/index.txt
+[bsd-3]: http://opensource.org/licenses/BSD-3-Clause
+[gnu gpl v3.0]: http://www.gnu.org/licenses/gpl-3.0.txt
+[gnu lgpl v3.0]: http://www.gnu.org/licenses/lgpl-3.0.txt
+[apache v2.0]: http://www.apache.org/licenses/LICENSE-2.0

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -160,6 +160,7 @@ This prompt allows you to choose from a variety of open source licensing options
 for your plugin. Choosing any of the options will lead to a boilerplate `LICENSE`
 file being added to the root of your plugin directory, as well as the [SPDX identifier](https://spdx.org/licenses/)
 for that license being listed in your `setup.cfg` under the `license` field.
+
 License options include: [BSD-3], [MIT], [MPL v2.0], [Apache v2.0], [GNU GPL v3.0], or [GNU LGPL v3.0]
 
 

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -160,7 +160,7 @@ This prompt allows you to choose from a variety of open source licensing options
 for your plugin. Choosing any of the options will lead to a boilerplate `LICENSE`
 file being added to the root of your plugin directory, as well as the [SPDX identifier](https://spdx.org/licenses/)
 for that license being listed in your `setup.cfg` under the `license` field.
-License options include: [BSD-3], [MIT], [MPL v2.0], [Apachev2.0], [GNU GPL v3.0], or [GNU LGPL v3.0]
+License options include: [BSD-3], [MIT], [MPL v2.0], [Apache v2.0], [GNU GPL v3.0], or [GNU LGPL v3.0]
 
 
 [spec]: https://napari.org/plugins/stable/npe2_manifest_specification.html

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -152,7 +152,7 @@ plugin documentation, check out the [mkdocs documentation](https://www.mkdocs.or
 
 If you choose `sphinx`, the relevant config files will be placed in a `sphinx` folder
 at the root of your plugin directory. For more information on using `sphinx` for
-your plugin documentation, check out the [sphinx documentation](https://www.sphinx-doc.org/en/main/).
+your plugin documentation, check out the [sphinx documentation](https://www.sphinx-doc.org/).
 
 ## license
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install [Cookiecutter] and generate a new napari plugin project:
 
 ```bash
 pip install cookiecutter
-cookiecutter https://github.com/napari/cookiecutter-napari-plugin
+cookiecutter https://github.com/napari/cookiecutter-napari-plugin --checkout npe2
 ```
 
 Cookiecutter prompts you for information regarding your plugin


### PR DESCRIPTION
I noticed just a couple of small things on some of the links on the PROMTS.md docs that I thought I'd go ahead and add a fix for.
1. The link for sphinx documentation was wrong.
2. I thought it would be nice to have the links for the available licenses on the license section.  I expected it there before I found them lower down on the main README page.  

A question---the links for the hook specification references are not working right now.  I noticed they are npe2 links.  Are those going to be added at some point? Are they there, but these are just not working?

Note:  I tried to have this PR merging into the npe2 branch.  Double check that this is happening correctly!  😬 