### PR TITLE
Add `GabrielBB/xvfb-action` to plugin test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,4 +40,6 @@ jobs:
           pip install pytest pytest-cookies tox
 
       - name: Test
-        run: pytest -s -v --color=yes
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: pytest -s -v --color=yes

--- a/{{cookiecutter.plugin_name}}/.github/workflows/test_and_deploy.yml
+++ b/{{cookiecutter.plugin_name}}/.github/workflows/test_and_deploy.yml
@@ -33,8 +33,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      # these libraries, along with pytest-xvfb (added in the `deps` in tox.ini),
-      # enable testing on Qt on linux
+      # these libraries enable testing on Qt on linux
       - name: Install Linux libraries
         if: runner.os == 'Linux'
         run: |

--- a/{{cookiecutter.plugin_name}}/.github/workflows/test_and_deploy.yml
+++ b/{{cookiecutter.plugin_name}}/.github/workflows/test_and_deploy.yml
@@ -60,7 +60,9 @@ jobs:
 
       # this runs the platform-specific tests declared in tox.ini
       - name: Test with tox
-        run: tox
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: tox
         env:
           PLATFORM: ${{ matrix.platform }}
 

--- a/{{cookiecutter.plugin_name}}/tox.ini
+++ b/{{cookiecutter.plugin_name}}/tox.ini
@@ -28,7 +28,6 @@ passenv =
 deps = 
     pytest  # https://docs.pytest.org/en/latest/contents.html
     pytest-cov  # https://pytest-cov.readthedocs.io/en/latest/
-    pytest-xvfb ; sys_platform == 'linux'
     # you can remove these if you don't use them
     napari
     magicgui


### PR DESCRIPTION
This PR uses the xvfb GitHub Action for running tests with tox rather than `pytest-xvfb`, and removes `pytest-xvfb` from tox dependencies. This seems to perform better in avoiding the sporadic `XIO:  fatal IO error 0 (Success) on X server ":0"` errors we see on action runs.