### PR TITLE
Tweak `dock_widget` tests to get rid of `add_plugin_dock_widget`

### DIFF
--- a/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/__init__.py
+++ b/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/__init__.py
@@ -9,5 +9,5 @@ __version__ = "0.0.1"
 
 {% if cookiecutter.include_reader_plugin == 'y' %}from ._reader import napari_get_reader{% endif %}
 {% if cookiecutter.include_writer_plugin == 'y' %}from ._writer import napari_get_writer, napari_write_image{% endif %}
-{% if cookiecutter.include_dock_widget_plugin == 'y' %}from ._dock_widget import napari_experimental_provide_dock_widget{% endif %}
+{% if cookiecutter.include_dock_widget_plugin == 'y' %}from ._dock_widget import napari_experimental_provide_dock_widget, ExampleQWidget, example_magic_widget{% endif %}
 {% if cookiecutter.include_function_plugin == 'y' %}from ._function import napari_experimental_provide_function{% endif %}

--- a/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_tests/test_dock_widget.py
+++ b/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_tests/test_dock_widget.py
@@ -1,18 +1,25 @@
-import {{cookiecutter.module_name}}
+from {{cookiecutter.module_name}} import ExampleQWidget, example_magic_widget
+import numpy as np
 import pytest
 
-# this is your plugin name declared in your napari.plugins entry point
-MY_PLUGIN_NAME = "{{cookiecutter.plugin_name}}"
-# the name of your widget(s)
-MY_WIDGET_NAMES = ["Example Q Widget", "example_magic_widget"]
+@pytest.fixture
+def random_im():
+    return np.random.random((100, 100))
 
-
-@pytest.mark.parametrize("widget_name", MY_WIDGET_NAMES)
-def test_something_with_viewer(widget_name, make_napari_viewer, napari_plugin_manager):
-    napari_plugin_manager.register({{cookiecutter.module_name}}, name=MY_PLUGIN_NAME)
+def test_example_q_widget(make_napari_viewer, capsys, random_im):
     viewer = make_napari_viewer()
-    num_dw = len(viewer.window._dock_widgets)
-    viewer.window.add_plugin_dock_widget(
-        plugin_name=MY_PLUGIN_NAME, widget_name=widget_name
-    )
-    assert len(viewer.window._dock_widgets) == num_dw + 1
+    viewer.add_image(random_im)
+    my_widget = ExampleQWidget(viewer)
+    my_widget._on_click()
+
+    captured = capsys.readouterr()
+    assert captured.out == "napari has 1 layers\n"
+    
+def test_example_magic_widget(make_napari_viewer, capsys, random_im):
+    viewer = make_napari_viewer()
+    layer = viewer.add_image(random_im)
+    my_widget = example_magic_widget()
+
+    my_widget(viewer.layers[0])
+    captured = capsys.readouterr()
+    assert captured.out == f"you have selected {layer}\n"

--- a/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_tests/test_dock_widget.py
+++ b/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_tests/test_dock_widget.py
@@ -2,24 +2,40 @@ from {{cookiecutter.module_name}} import ExampleQWidget, example_magic_widget
 import numpy as np
 import pytest
 
+# we create a fixture that returns us a random image array
+# we can then pass this fixture as an argument to our tests
 @pytest.fixture
 def random_im():
     return np.random.random((100, 100))
 
+# make_napari_viewer is a pytest fixture that returns a napari viewer object
+# capsys is a pytest fixture that captures stdout and stderr output streams
+# random_im is the pytest fixture we defined above
 def test_example_q_widget(make_napari_viewer, capsys, random_im):
+    # make viewer and add an image layer using our fixture
     viewer = make_napari_viewer()
     viewer.add_image(random_im)
+
+    # create our widget, passing in the viewer
     my_widget = ExampleQWidget(viewer)
+
+    # call our widget method
     my_widget._on_click()
 
+    # read captured output and check that it's as we expected
     captured = capsys.readouterr()
     assert captured.out == "napari has 1 layers\n"
     
 def test_example_magic_widget(make_napari_viewer, capsys, random_im):
     viewer = make_napari_viewer()
     layer = viewer.add_image(random_im)
+
+    # this time, our widget will be a MagicFactory or FunctionGui instance
     my_widget = example_magic_widget()
 
+    # if we "call" this object, it'll execute our function
     my_widget(viewer.layers[0])
+
+    # read captured output and check that it's as we expected
     captured = capsys.readouterr()
     assert captured.out == f"you have selected {layer}\n"

--- a/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_tests/test_dock_widget.py
+++ b/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_tests/test_dock_widget.py
@@ -1,20 +1,12 @@
 from {{cookiecutter.module_name}} import ExampleQWidget, example_magic_widget
 import numpy as np
-import pytest
-
-# we create a fixture that returns us a random image array
-# we can then pass this fixture as an argument to our tests
-@pytest.fixture
-def random_im():
-    return np.random.random((100, 100))
 
 # make_napari_viewer is a pytest fixture that returns a napari viewer object
 # capsys is a pytest fixture that captures stdout and stderr output streams
-# random_im is the pytest fixture we defined above
-def test_example_q_widget(make_napari_viewer, capsys, random_im):
+def test_example_q_widget(make_napari_viewer, capsys):
     # make viewer and add an image layer using our fixture
     viewer = make_napari_viewer()
-    viewer.add_image(random_im)
+    viewer.add_image(np.random.random((100, 100)))
 
     # create our widget, passing in the viewer
     my_widget = ExampleQWidget(viewer)
@@ -26,9 +18,9 @@ def test_example_q_widget(make_napari_viewer, capsys, random_im):
     captured = capsys.readouterr()
     assert captured.out == "napari has 1 layers\n"
     
-def test_example_magic_widget(make_napari_viewer, capsys, random_im):
+def test_example_magic_widget(make_napari_viewer, capsys):
     viewer = make_napari_viewer()
-    layer = viewer.add_image(random_im)
+    layer = viewer.add_image(np.random.random((100, 100)))
 
     # this time, our widget will be a MagicFactory or FunctionGui instance
     my_widget = example_magic_widget()


### PR DESCRIPTION
This PR removes code that tries to register the plugin and add dock widgets to the viewer, and instead focuses on testing widget functionality. We still use `make_napari_viewer` to pass the `viewer` as a parent widget when we create our dock widget.

I've also added a fixture that returns an image array and some explanatory comments.