### PR TITLE
fix test on windows

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -83,7 +83,7 @@ def validate_manifest():
     except Exception as err:
         msg = f"🅇 Failed to read {path!r}. {type(err).__name__}: {err}"
     
-    print(msg)
+    print(msg.encode("utf-8"))
     return valid
 
 


### PR DESCRIPTION
Fixes a `print` statement that was causing tests to fail on my windows machine.