### PR TITLE
remove foobar submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ venv.bak/
 
 # VSCode
 .vscode/
+napari-foobar/


### PR DESCRIPTION
Removes the rendered napari-foobar submodule that snuck into the last commit, and adds to gitignore