### PR TITLE
fix include_package_data in npe2 branch

### DIFF
--- a/{{cookiecutter.plugin_name}}/setup.cfg
+++ b/{{cookiecutter.plugin_name}}/setup.cfg
@@ -24,7 +24,6 @@ license = MPL-2.0
 description = {{cookiecutter.short_description}}
 long_description = file: README.md
 long_description_content_type = text/markdown
-include_package_data = True
 classifiers =
     Development Status :: 2 - Pre-Alpha
     Intended Audience :: Developers
@@ -59,6 +58,7 @@ project_urls =
 
 [options]
 packages = find:
+include_package_data = True
 python_requires = >=3.7
 package_dir =
     =src


### PR DESCRIPTION
Just noticed that @brisvag's package published with the npe2 cookiecutter is lacking napari.yaml in the wheel
https://pypi.org/project/napari-molecule-reader/#files

`include_package_data` is in the wrong section, this fixes