### PR TITLE
fix windows issue with xvfb

### DIFF
--- a/{{cookiecutter.plugin_name}}/.github/workflows/test_and_deploy.yml
+++ b/{{cookiecutter.plugin_name}}/.github/workflows/test_and_deploy.yml
@@ -50,13 +50,13 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools tox tox-gh-actions
+          python -m pip install setuptools tox tox-gh-actions
 
       # this runs the platform-specific tests declared in tox.ini
       - name: Test with tox
         uses: GabrielBB/xvfb-action@v1
         with:
-          run: tox
+          run: python -m tox
         env:
           PLATFORM: ${{ matrix.platform }}
 


### PR DESCRIPTION
The GitHub action tests currently fail on Windows. This fix uses the same solution as found in https://github.com/napari/superqt/pull/61/commits/489eae8c898c7afecf5120c03c0a81e28e545a63 by explicitly calling ```python -m``` to execute installations with ```pip``` and to run ```tox```.