### PR TITLE
Bumpy python to 3.8, use more general [options.package_data] entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ nice with conda.
 
 ```bash
 pip install tox tox-conda
-tox -e py36,py37,py38 # run tests on multiple python versions
+tox -e py38,py39,py310 # run tests on multiple python versions
 ```
 
 If you don't wish to test locally on all supported python versions, you can test

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 recreate = true
 skipsdist = true
-envlist = py{37,38,39}
+envlist = py{38,39,310}
 toxworkdir = /tmp/.tox
 
 [testenv]

--- a/{{cookiecutter.plugin_name}}/.github/workflows/test_and_deploy.yml
+++ b/{{cookiecutter.plugin_name}}/.github/workflows/test_and_deploy.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10']
 
     steps:
       - uses: actions/checkout@v2

--- a/{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     rev: v2.29.1
     hooks:
       - id: pyupgrade
-        args: [--py37-plus, --keep-runtime-typing]
+        args: [--py38-plus, --keep-runtime-typing]
   - repo: https://github.com/tlambert03/napari-plugin-checks
     rev: v0.2.0
     hooks:

--- a/{{cookiecutter.plugin_name}}/setup.cfg
+++ b/{{cookiecutter.plugin_name}}/setup.cfg
@@ -31,7 +31,6 @@ classifiers =
     Topic :: Software Development :: Testing
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -60,7 +59,7 @@ project_urls =
 [options]
 packages = find:
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.8
 package_dir =
     =src
 {% if cookiecutter.use_git_tags_for_versioning == 'y' -%}
@@ -74,8 +73,7 @@ install_requires =
 where = src
 
 [options.package_data]
-{{cookiecutter.plugin_name}} = 
-    napari.yaml
+* = *.yaml
 
 [options.entry_points] 
 napari.manifest = 

--- a/{{cookiecutter.plugin_name}}/tox.ini
+++ b/{{cookiecutter.plugin_name}}/tox.ini
@@ -1,11 +1,10 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{37,38,39,310}-{linux,macos,windows}
+envlist = py{38,39,310}-{linux,macos,windows}
 isolated_build=true
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310


### PR DESCRIPTION
changing the package data entry to:

```ini
[options.package_data]
* = *.yaml
```

See #100 ... not entirely sure why the current entry was working for the default cookiecutter, but not in that case, but this entry for package data more generally includes any yaml files found.  (Users can further tune if they need to)

Side-note, technically I think we could just remove that bit altogether (the `include_package_data = True` in the `[options]` should be sufficient) ... but this is a bit safer i guess