### PR TITLE
Update flake8_tpying_imports and make flake8 and black compatible

### DIFF
--- a/{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     rev: 4.0.1
     hooks:
       - id: flake8
-        additional_dependencies: [flake8-typing-imports==1.7.0]
+        additional_dependencies: [flake8-typing-imports==1.12.0]
   - repo: https://github.com/myint/autoflake
     rev: v1.4
     hooks:

--- a/{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     rev: 4.0.1
     hooks:
       - id: flake8
-        additional_dependencies: [flake8-typing-imports==1.12.0]
+        additional_dependencies: [flake8-typing-imports>=1.9.0]
   - repo: https://github.com/myint/autoflake
     rev: v1.4
     hooks:

--- a/{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/{{cookiecutter.plugin_name}}/pyproject.toml
@@ -10,3 +10,6 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 write_to = "src/{{cookiecutter.module_name}}/_version.py"
 {%- endif %}
+
+[tool.black]
+line-length = 79

--- a/{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/{{cookiecutter.plugin_name}}/pyproject.toml
@@ -13,3 +13,7 @@ write_to = "src/{{cookiecutter.module_name}}/_version.py"
 
 [tool.black]
 line-length = 79
+
+[tool.isort]
+profile = "black"
+line_length = 79

--- a/{{cookiecutter.plugin_name}}/tox.ini
+++ b/{{cookiecutter.plugin_name}}/tox.ini
@@ -36,3 +36,6 @@ deps =
     qtpy
     pyqt5
 commands = pytest -v --color=yes --cov={{cookiecutter.module_name}} --cov-report=xml
+
+[flake8]
+max-line-length=88

--- a/{{cookiecutter.plugin_name}}/tox.ini
+++ b/{{cookiecutter.plugin_name}}/tox.ini
@@ -36,6 +36,3 @@ deps =
     qtpy
     pyqt5
 commands = pytest -v --color=yes --cov={{cookiecutter.module_name}} --cov-report=xml
-
-[flake8]
-max-line-length=88


### PR DESCRIPTION
Hi,
I just had problems with the pre-commit workflows.

I changed the version of `flake8_tpying_imports` from 1.7.0 to 1.12.0 in `.pre-commit-config.yaml`.

Furthermore, flake8 was not aware of the max line length of 88 introduced by black. So I added it in the end of the `tox.ini`.