### PR TITLE
Fix issue with github CI

### DIFF
--- a/{{cookiecutter.plugin_name}}/.github/workflows/test_and_deploy.yml
+++ b/{{cookiecutter.plugin_name}}/.github/workflows/test_and_deploy.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Windows OpenGL
         if: runner.os == 'Windows'
         run: |
-          git clone --depth 1 git://github.com/pyvista/gl-ci-helpers.git
+          git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
 
       # note: if you need dependencies from conda, considering using


### PR DESCRIPTION
Hi all,

I'm suggesting to change this line in the napari plugin template, because it causes the following error in the github CI of likely all napari plugins:

```
Run git clone --depth 1 git://github.com/pyvista/gl-ci-helpers.git
Cloning into 'gl-ci-helpers'...
fatal: remote error: 
  The unauthenticated git protocol on port 941[8](https://github.com/haesleinhuepf/napari-workflows/runs/5616765422?check_suite_focus=true#step:5:8) is no longer supported.
Please see https://github.blog/2021-0[9](https://github.com/haesleinhuepf/napari-workflows/runs/5616765422?check_suite_focus=true#step:5:9)-01-improving-git-protocol-security-github/ for more information.
gl-ci-helpers/appveyor/install_opengl.ps1 : The term 'gl-ci-helpers/appveyor/install_opengl.ps1' is not recognized as 
the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was 
included, verify that the path is correct and try again.
At line:1 char:1
+ gl-ci-helpers/appveyor/install_opengl.ps1
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (gl-ci-helpers/a...tall_opengl.ps1:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
```

Credits to @jo-mueller for pointing out the solution. See:
* https://github.com/BiAPoL/napari-clusters-plotter/pull/64

Best,
Robert