### PR TITLE
Move flake8 checks after all hooks that could modify code

### DIFF
--- a/{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
@@ -9,24 +9,24 @@ repos:
     rev: v1.20.0
     hooks:
       - id: setup-cfg-fmt
-  - repo: https://github.com/myint/autoflake
-    rev: v1.4
-    hooks:
-      - id: autoflake
-        args: ["--in-place", "--remove-all-unused-imports"]
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:
       - id: isort
-  - repo: https://github.com/psf/black
-    rev: 21.11b1
-    hooks:
-      - id: black
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.29.1
     hooks:
       - id: pyupgrade
         args: [--py38-plus, --keep-runtime-typing]
+  - repo: https://github.com/myint/autoflake
+    rev: v1.4
+    hooks:
+      - id: autoflake
+        args: ["--in-place", "--remove-all-unused-imports"]
+  - repo: https://github.com/psf/black
+    rev: 21.11b1
+    hooks:
+      - id: black
   - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:

--- a/{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.2.0
     hooks:
       - id: check-docstring-first
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.20.0
+    rev: v1.20.1
     hooks:
       - id: setup-cfg-fmt
   - repo: https://github.com/PyCQA/isort
@@ -14,7 +14,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.1
+    rev: v2.32.1
     hooks:
       - id: pyupgrade
         args: [--py38-plus, --keep-runtime-typing]
@@ -24,7 +24,7 @@ repos:
       - id: autoflake
         args: ["--in-place", "--remove-all-unused-imports"]
   - repo: https://github.com/psf/black
-    rev: 21.11b1
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/flake8

--- a/{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
@@ -9,11 +9,6 @@ repos:
     rev: v1.20.0
     hooks:
       - id: setup-cfg-fmt
-  - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
-    hooks:
-      - id: flake8
-        additional_dependencies: [flake8-typing-imports>=1.9.0]
   - repo: https://github.com/myint/autoflake
     rev: v1.4
     hooks:
@@ -32,6 +27,11 @@ repos:
     hooks:
       - id: pyupgrade
         args: [--py38-plus, --keep-runtime-typing]
+  - repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-typing-imports>=1.9.0]
   - repo: https://github.com/tlambert03/napari-plugin-checks
     rev: v0.2.0
     hooks:


### PR DESCRIPTION
Currently, flake8 hook is executed before all commits that could modify files (especially autoflake). So it may happen that there will be reported errors that are already fixed. But also errors could be reported in the wrong line (as file fixes, for example, black could change line numbers). 