### PR TITLE
Fix make_sample_data return value

### DIFF
--- a/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_sample_data.py
+++ b/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_sample_data.py
@@ -13,4 +13,9 @@ import numpy
 
 def make_sample_data():
     """Generates an image"""
-    return numpy.random.rand(512, 512)
+    # Return list of tuples
+    # [(data1, add_image_kwargs1), (data2, add_image_kwargs2)]
+    # Check the documentation for more information about the
+    # add_image_kwargs
+    # https://napari.org/api/napari.Viewer.html#napari.Viewer.add_image
+    return [(numpy.random.rand(512, 512), {})]


### PR DESCRIPTION
I just did a plugin installation via cookiecutter, but loading the sample data lead to:

`TypeError: ViewerModel._add_layer_from_data() takes from 2 to 4 positional arguments but 513 were given`

I checked the code here:
https://github.com/napari/napari/blob/main/napari/plugins/_skimage_data.py

and adapted the make_sample_data return values accordingly.