### PR TITLE
add return values to writer template

### DIFF
--- a/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_writer.py
+++ b/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_writer.py
@@ -15,9 +15,15 @@ if TYPE_CHECKING:
     FullLayerData = Tuple[DataType, dict, str]
 
 
-def write_single_image(path: str, data: Any, meta: dict):
+def write_single_image(path: str, data: Any, meta: dict) -> List[str]:
     """Writes a single image layer"""
 
+    # return path to any file(s) that were successfully written
+    return [path] 
 
-def write_multiple(path: str, data: List[FullLayerData]):
+
+def write_multiple(path: str, data: List[FullLayerData]) -> List[str]:
     """Writes multiple layers of different types."""
+
+    # return path to any file(s) that were successfully written
+    return [path]

--- a/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_writer.py
+++ b/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_writer.py
@@ -31,4 +31,3 @@ def write_multiple(path: str, data: List[FullLayerData]) -> List[str]:
 
     # return path to any file(s) that were successfully written
     return [path]
- 

--- a/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_writer.py
+++ b/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_writer.py
@@ -31,3 +31,4 @@ def write_multiple(path: str, data: List[FullLayerData]) -> List[str]:
 
     # return path to any file(s) that were successfully written
     return [path]
+ 

--- a/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_writer.py
+++ b/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_writer.py
@@ -18,12 +18,16 @@ if TYPE_CHECKING:
 def write_single_image(path: str, data: Any, meta: dict) -> List[str]:
     """Writes a single image layer"""
 
+    # implement your writer logic here ...
+
     # return path to any file(s) that were successfully written
     return [path] 
 
 
 def write_multiple(path: str, data: List[FullLayerData]) -> List[str]:
     """Writes multiple layers of different types."""
+
+    # implement your writer logic here ...
 
     # return path to any file(s) that were successfully written
     return [path]


### PR DESCRIPTION
Writer's need to return written paths in order to indicate success to napari, but this isn't done in the writer template.  

This PR adds return values to the template.