### PR TITLE
remove setupcfg format

### DIFF
--- a/{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
@@ -5,10 +5,6 @@ repos:
       - id: check-docstring-first
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.20.1
-    hooks:
-      - id: setup-cfg-fmt
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:

--- a/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_writer.py
+++ b/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_writer.py
@@ -21,7 +21,7 @@ def write_single_image(path: str, data: Any, meta: dict) -> List[str]:
     # implement your writer logic here ...
 
     # return path to any file(s) that were successfully written
-    return [path] 
+    return [path]
 
 
 def write_multiple(path: str, data: List[FullLayerData]) -> List[str]:


### PR DESCRIPTION
removes setupcfg format from pre-commit.  It's too opinionated, and changes too frequently.

also fixes a formatting error that somehow made it through CI in #130 