### PR TITLE
ignore whitespace in napari-hub, and remove setup-cfg-fmt test

### DIFF
--- a/tests/test_create_template.py
+++ b/tests/test_create_template.py
@@ -92,6 +92,4 @@ def test_pre_commit_validity(cookies, include_reader_plugin, include_writer_plug
         }
     )
     result.project_path.joinpath("setup.cfg").is_file()
-    subprocess.run(["pre-commit", "run", "setup-cfg-fmt", "--all"], cwd=str(result.project_path), check=False, capture_output=True)
-    # workaround because setup-cfg-fmt does not keep comments https://github.com/asottile/setup-cfg-fmt/pull/21
     subprocess.run(["pre-commit", "run", "--all"], cwd=str(result.project_path), check=True, capture_output=True)

--- a/{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
       - id: check-docstring-first
       - id: end-of-file-fixer
       - id: trailing-whitespace
+        exclude: ^.napari-hub/*
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:


### PR DESCRIPTION
removes a line in a test no longer needed after #135, and excludes napari-hub from linting requirements