### PR TITLE
Fix windows tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install tox
+          pip install pytest tox
+          pip install git+https://github.com/andriihomiak/pytest-cookies.git@fix/quotes_in_user_config
 
       - name: Test
         uses: GabrielBB/xvfb-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pytest tox
-          pip install git+https://github.com/andriihomiak/pytest-cookies.git@fix/quotes_in_user_config
+          pip install git+https://github.com/hackebrot/pytest-cookies.git@refs/pull/61/head
 
       - name: Test
         uses: GabrielBB/xvfb-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-cookies tox
+          pip install tox
 
       - name: Test
         uses: GabrielBB/xvfb-action@v1

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ toxworkdir = /tmp/.tox
 
 [testenv]
 deps = pytest
-       git+https://github.com/andriihomiak/pytest-cookies.git@fix/quotes_in_user_config#egg=pytest-cookies
+       git+https://github.com/hackebrot/pytest-cookies.git@refs/pull/61/head
        tox
 commands = pytest -v {posargs:tests}
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ toxworkdir = /tmp/.tox
 
 [testenv]
 deps = pytest
-       pytest-cookies
+       git+https://github.com/andriihomiak/pytest-cookies.git@fix/quotes_in_user_config
        tox
 commands = pytest -v {posargs:tests}
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ toxworkdir = /tmp/.tox
 
 [testenv]
 deps = pytest
-       git+https://github.com/andriihomiak/pytest-cookies.git@fix/quotes_in_user_config
+       git+https://github.com/andriihomiak/pytest-cookies.git@fix/quotes_in_user_config#egg=pytest-cookies
        tox
 commands = pytest -v {posargs:tests}
 


### PR DESCRIPTION
Windows tests are failing due to `cookiecutter` issue:
https://github.com/cookiecutter/cookiecutter/issues/1688
This is solved with a PR to `pytest-cookie` but it's not merged (despite months of time...):
https://github.com/hackebrot/pytest-cookies/pull/61

So this PR uses that PR branch for `pytest-cookies` to eliminate the fails.
If the PR is every merged, can go back to just `pytest-cookies`