### PR TITLE
Fix order of tox argument in test run

### DIFF
--- a/tests/test_create_template.py
+++ b/tests/test_create_template.py
@@ -14,7 +14,7 @@ def run_tox(plugin):
     """Run the tox suite of the newly created plugin."""
     try:
         subprocess.check_call(
-            ["tox", plugin, "-c", os.path.join(plugin, "tox.ini"), "-e", "py"]
+            ["tox", "-c", os.path.join(plugin, "tox.ini"), "-e", "py", "--", plugin]
         )
     except subprocess.CalledProcessError as e:
         pytest.fail("Subprocess fail", pytrace=True)


### PR DESCRIPTION
since tox 4 there is a requirement to move arguments passed to pytest on the end of the call and separate int with `"--"`. 