### PR TITLE
Update isort version in pre-commit config

### DIFF
--- a/{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: trailing-whitespace
         exclude: ^\.napari-hub/.*
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/asottile/pyupgrade


### PR DESCRIPTION
The previous version was failing to install due to some issues with poetry. See https://github.com/PyCQA/isort/pull/2078.