### PR TITLE
Docstrings describing inputs to writer functions

### DIFF
--- a/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_writer.py
+++ b/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_writer.py
@@ -21,12 +21,16 @@ def write_single_image(path: str, data: Any, meta: dict) -> List[str]:
     Parameters
     ----------
     path : str
-    data : The layer data attribute
+           A string path indicating where to save the image file.
+    data : The layer data
+           The `.data` attribute from the napari layer.
     meta : dict
+           A dictionary containing all other attributes from the napari layer
+           (excluding the `.data` layer attribute).
 
     Returns
     -------
-    [path] : A list containing the string path to the saved file
+    [path] : A list containing the string path to the saved file.
     """
 
     # implement your writer logic here ...
@@ -41,16 +45,16 @@ def write_multiple(path: str, data: List[FullLayerData]) -> List[str]:
     Parameters
     ----------
     path : str
+           A string path indicating where to save the image file.
     data : A layer tuple.
            Tuple contains three elements: (data, kwargs, layer_type)
            `data` is the layer data
            `kwargs` is a dictionary of keyword arguments
            `layer_type` is a string, eg: "image", "labels", "surface", etc.
-    meta : dict
 
     Returns
     -------
-    [path] : A list containing multiple string paths to the saved files
+    [path] : A list containing multiple string paths to the saved files.
     """
 
     # implement your writer logic here ...

--- a/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_writer.py
+++ b/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_writer.py
@@ -16,7 +16,17 @@ if TYPE_CHECKING:
 
 
 def write_single_image(path: str, data: Any, meta: dict) -> List[str]:
-    """Writes a single image layer"""
+    """Writes a single image layer.
+    
+    Parameters
+    ----------
+    path : str
+    data : The layer data
+
+    Returns
+    -------
+    [path] : A list containing the string path to the saved file
+    """
 
     # implement your writer logic here ...
 
@@ -25,7 +35,21 @@ def write_single_image(path: str, data: Any, meta: dict) -> List[str]:
 
 
 def write_multiple(path: str, data: List[FullLayerData]) -> List[str]:
-    """Writes multiple layers of different types."""
+    """Writes multiple layers of different types.
+    
+    Parameters
+    ----------
+    path : str
+    data : A layer tuple.
+           Tuple contains three elements: (data, kwargs, layer_type)
+           `data` is the layer data
+           `kwargs` is a dictionary of keyword arguments
+           `layer_type` is a string, eg: "image", "labels", "surface", etc.
+
+    Returns
+    -------
+    [path] : A list containing multiple string paths to the saved files
+    """
 
     # implement your writer logic here ...
 

--- a/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_writer.py
+++ b/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_writer.py
@@ -45,7 +45,7 @@ def write_multiple(path: str, data: List[FullLayerData]) -> List[str]:
     Parameters
     ----------
     path : str
-        A string path indicating where to save the image file.
+        A string path indicating where to save the data file(s).
     data : A list of layer tuples.
         Tuples contain three elements: (data, meta, layer_type)
          data` is the layer data

--- a/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_writer.py
+++ b/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_writer.py
@@ -48,7 +48,7 @@ def write_multiple(path: str, data: List[FullLayerData]) -> List[str]:
         A string path indicating where to save the data file(s).
     data : A list of layer tuples.
         Tuples contain three elements: (data, meta, layer_type)
-         data` is the layer data
+        `data` is the layer data
         `meta` is a dictionary containing all other metadata attributes
         from the napari layer (excluding the `.data` layer attribute).
         `layer_type` is a string, eg: "image", "labels", "surface", etc.

--- a/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_writer.py
+++ b/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_writer.py
@@ -21,7 +21,8 @@ def write_single_image(path: str, data: Any, meta: dict) -> List[str]:
     Parameters
     ----------
     path : str
-    data : The layer data
+    data : The layer data attribute
+    meta : dict
 
     Returns
     -------
@@ -45,6 +46,7 @@ def write_multiple(path: str, data: List[FullLayerData]) -> List[str]:
            `data` is the layer data
            `kwargs` is a dictionary of keyword arguments
            `layer_type` is a string, eg: "image", "labels", "surface", etc.
+    meta : dict
 
     Returns
     -------

--- a/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_writer.py
+++ b/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_writer.py
@@ -47,9 +47,10 @@ def write_multiple(path: str, data: List[FullLayerData]) -> List[str]:
     path : str
            A string path indicating where to save the image file.
     data : A layer tuple.
-           Tuple contains three elements: (data, kwargs, layer_type)
+           Tuple contains three elements: (data, meta, layer_type)
            `data` is the layer data
-           `kwargs` is a dictionary of keyword arguments
+           `meta` is a dictionary containing all other metadata attributes
+                  from the napari layer (excluding the `.data` layer attribute).
            `layer_type` is a string, eg: "image", "labels", "surface", etc.
 
     Returns

--- a/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_writer.py
+++ b/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_writer.py
@@ -21,12 +21,12 @@ def write_single_image(path: str, data: Any, meta: dict) -> List[str]:
     Parameters
     ----------
     path : str
-           A string path indicating where to save the image file.
+        A string path indicating where to save the image file.
     data : The layer data
-           The `.data` attribute from the napari layer.
+        The `.data` attribute from the napari layer.
     meta : dict
-           A dictionary containing all other attributes from the napari layer
-           (excluding the `.data` layer attribute).
+        A dictionary containing all other attributes from the napari layer
+        (excluding the `.data` layer attribute).
 
     Returns
     -------
@@ -45,13 +45,13 @@ def write_multiple(path: str, data: List[FullLayerData]) -> List[str]:
     Parameters
     ----------
     path : str
-           A string path indicating where to save the image file.
-    data : A layer tuple.
-           Tuple contains three elements: (data, meta, layer_type)
-           `data` is the layer data
-           `meta` is a dictionary containing all other metadata attributes
-                  from the napari layer (excluding the `.data` layer attribute).
-           `layer_type` is a string, eg: "image", "labels", "surface", etc.
+        A string path indicating where to save the image file.
+    data : A list of layer tuples.
+        Tuples contain three elements: (data, meta, layer_type)
+         data` is the layer data
+        `meta` is a dictionary containing all other metadata attributes
+        from the napari layer (excluding the `.data` layer attribute).
+        `layer_type` is a string, eg: "image", "labels", "surface", etc.
 
     Returns
     -------

--- a/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_writer.py
+++ b/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/_writer.py
@@ -55,7 +55,7 @@ def write_multiple(path: str, data: List[FullLayerData]) -> List[str]:
 
     Returns
     -------
-    [path] : A list containing multiple string paths to the saved files.
+    [path] : A list containing (potentially multiple) string paths to the saved file(s).
     """
 
     # implement your writer logic here ...


### PR DESCRIPTION
The cookiecutter writer functions do not describe what inputs they expect adequately. This PR attempts to improve that.

In particular, it is confusing because the input `data` in function `write_single_image` is not the same type of object as the input `data` in function `write_multiple`.

I've used numpy style docstring formatting here, mostly because I didn't see enough other docstrings to know what docstring format I should use for this project. We can change it, of course.