### PR TITLE
Switch to ruff pre-commit, fix .project cookiecutter deprecation

### DIFF
--- a/tests/test_create_template.py
+++ b/tests/test_create_template.py
@@ -26,13 +26,13 @@ def test_run_cookiecutter_and_plugin_tests(cookies, capsys):
 
     assert result.exit_code == 0
     assert result.exception is None
-    assert result.project.basename == "foo-bar"
-    assert result.project.isdir()
-    assert result.project.join("src").isdir()
-    assert result.project.join("src", "foo_bar", "__init__.py").isfile()
-    assert result.project.join("src", "foo_bar", "_tests", "test_reader.py").isfile()
+    assert result.project_path.name == "foo-bar"
+    assert result.project_path.is_dir()
+    assert result.project_path.joinpath("src").is_dir()
+    assert result.project_path.joinpath("src", "foo_bar", "__init__.py").is_file()
+    assert result.project_path.joinpath("src", "foo_bar", "_tests", "test_reader.py").is_file()
 
-    run_tox(str(result.project))
+    run_tox(str(result.project_path))
 
 
 def test_run_cookiecutter_and_plugin_tests_with_napari_prefix(cookies, capsys):
@@ -41,11 +41,11 @@ def test_run_cookiecutter_and_plugin_tests_with_napari_prefix(cookies, capsys):
 
     assert result.exit_code == 0
     assert result.exception is None
-    assert result.project.basename == "napari-foo"
-    assert result.project.isdir()
-    assert result.project.join("src").isdir()
-    assert result.project.join("src", "napari_foo", "__init__.py").isfile()
-    assert result.project.join("src", "napari_foo", "_tests", "test_reader.py").isfile()
+    assert result.project_path.name == "napari-foo"
+    assert result.project_path.is_dir()
+    assert result.project_path.joinpath("src").is_dir()
+    assert result.project_path.joinpath("src", "napari_foo", "__init__.py").is_file()
+    assert result.project_path.joinpath("src", "napari_foo", "_tests", "test_reader.py").is_file()
 
 
 def test_run_cookiecutter_select_plugins(cookies, capsys):
@@ -60,20 +60,20 @@ def test_run_cookiecutter_select_plugins(cookies, capsys):
 
     assert result.exit_code == 0
     assert result.exception is None
-    assert result.project.basename == "anything"
-    assert result.project.isdir()
-    assert result.project.join("src").isdir()
-    assert result.project.join("src", "anything", "__init__.py").isfile()
-    assert result.project.join("src", "anything", "_tests", "test_reader.py").isfile()
+    assert result.project_path.name == "anything"
+    assert result.project_path.is_dir()
+    assert result.project_path.joinpath("src").is_dir()
+    assert result.project_path.joinpath("src", "anything", "__init__.py").is_file()
+    assert result.project_path.joinpath("src", "anything", "_tests", "test_reader.py").is_file()
 
-    assert not result.project.join("src", "anything", "_widget.py").isfile()
-    assert not result.project.join(
+    assert not result.project_path.joinpath("src", "anything", "_widget.py").is_file()
+    assert not result.project_path.joinpath(
         "src", "anything", "_tests", "test_widget.py"
-    ).isfile()
-    assert not result.project.join("src", "anything", "_writer.py").isfile()
-    assert not result.project.join(
+    ).is_file()
+    assert not result.project_path.joinpath("src", "anything", "_writer.py").is_file()
+    assert not result.project_path.joinpath(
         "src", "anything", "_tests", "test_writer.py"
-    ).isfile()
+    ).is_file()
 
 
 @pytest.mark.parametrize("include_reader_plugin", ["y", "n"])

--- a/tests/test_create_template.py
+++ b/tests/test_create_template.py
@@ -92,4 +92,7 @@ def test_pre_commit_validity(cookies, include_reader_plugin, include_writer_plug
         }
     )
     result.project_path.joinpath("setup.cfg").is_file()
-    subprocess.run(["pre-commit", "run", "--all"], cwd=str(result.project_path), check=True, capture_output=True)
+    try:
+        subprocess.run(["pre-commit", "run", "--all", "--show-diff-on-failure"], cwd=str(result.project_path), check=True, capture_output=True)
+    except subprocess.CalledProcessError as e:
+        pytest.fail(f"pre-commit failed with output:\n{e.stdout.decode()}\nerrror:\n{e.stderr.decode()}")

--- a/{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
         exclude: ^\.napari-hub/.*
-      - id: check-yaml # checks for correct yaml syntax for github actions ex. 
+      - id: check-yaml # checks for correct yaml syntax for github actions ex.
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.0.256
     hooks:

--- a/{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
@@ -6,29 +6,15 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
         exclude: ^\.napari-hub/.*
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+      - id: check-yaml # checks for correct yaml syntax for github actions ex. 
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.256
     hooks:
-      - id: isort
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.1
-    hooks:
-      - id: pyupgrade
-        args: [--py38-plus, --keep-runtime-typing]
-  - repo: https://github.com/myint/autoflake
-    rev: v1.4
-    hooks:
-      - id: autoflake
-        args: ["--in-place", "--remove-all-unused-imports"]
+      - id: ruff
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:
       - id: black
-  - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
-    hooks:
-      - id: flake8
-        additional_dependencies: [flake8-typing-imports>=1.9.0]
   - repo: https://github.com/tlambert03/napari-plugin-checks
     rev: v0.2.0
     hooks:

--- a/{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/{{cookiecutter.plugin_name}}/pyproject.toml
@@ -33,7 +33,7 @@ select = [
 ]
 ignore = [
     "E501", # line to long. left this on black side
-    "UP006", "UP007" # type annotation. As using magicgui require runtime type annotation then we disable this. 
+    "UP006", "UP007", # type annotation. As using magicgui require runtime type annotation then we disable this.
     "SIM117", # flake8-simplify - some of merged with statements are not looking great with black, reanble after drop python 3.9
 ]
 

--- a/{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/{{cookiecutter.plugin_name}}/pyproject.toml
@@ -13,7 +13,51 @@ write_to = "src/{{cookiecutter.module_name}}/_version.py"
 
 [tool.black]
 line-length = 79
+target-version = ['py38', 'py39', 'py310']
 
-[tool.isort]
-profile = "black"
-line_length = 79
+
+[tool.ruff]
+line-length = 79
+select = [
+    "E", "F", "W", #flake8
+    "UP", # pyupgrade
+    "I", # isort
+    "BLE", # flake8-blind-exception
+    "B", # flake8-bugbear
+    "A", # flake8-builtins
+    "C4", # flake8-comprehensions
+    "ISC", # flake8-implicit-str-concat
+    "G", # flake8-logging-format
+    "PIE", # flake8-pie
+    "SIM", # flake8-simplify
+]
+ignore = [
+    "E501", # line to long. left this on black side
+    "UP006", "UP007" # type annotation. As using magicgui require runtime type annotation then we disable this. 
+    "SIM117", # flake8-simplify - some of merged with statements are not looking great with black, reanble after drop python 3.9
+]
+
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".mypy_cache",
+    ".pants.d",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+    "*vendored*",
+    "*_vendor*",
+]
+
+target-version = "py38"
+fix = true

--- a/{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/{{cookiecutter.plugin_name}}/pyproject.toml
@@ -32,7 +32,7 @@ select = [
     "SIM", # flake8-simplify
 ]
 ignore = [
-    "E501", # line to long. left this on black side
+    "E501", # line too long. let black handle this
     "UP006", "UP007", # type annotation. As using magicgui require runtime type annotation then we disable this.
     "SIM117", # flake8-simplify - some of merged with statements are not looking great with black, reanble after drop python 3.9
 ]


### PR DESCRIPTION
In this PR I remove falke8, isort, autoflake for a better user experience (shorter waiting on commit). 

In tests I replace `result.project` with `result.project_path` because of deprecation of `project` attribute. 

From test output:
```
   /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/pytest_cookies/plugin.py:36: DeprecationWarning: project is deprecated and will be removed in a future release, please use project_path instead.
```