### PR TITLE
Get `setup.cfg` version metadata from module when not using git tags versioning (`setuptools_scm`)

### DIFF
--- a/{{cookiecutter.plugin_name}}/setup.cfg
+++ b/{{cookiecutter.plugin_name}}/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = {{cookiecutter.plugin_name}}
 {% if cookiecutter.use_git_tags_for_versioning != 'y' -%}
-version = 0.0.1
+version = attr: {{cookiecutter.module_name}}.__version__
 {%- endif %}
 description = {{cookiecutter.short_description}}
 long_description = file: README.md


### PR DESCRIPTION
closes #155 