### PR TITLE
Update xvfb action for the repo itself to `aganders3/headless-gui@v1`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,6 @@ jobs:
           pip install git+https://github.com/hackebrot/pytest-cookies.git@refs/pull/61/head
 
       - name: Test
-        uses: GabrielBB/xvfb-action@v1
+        uses: aganders3/headless-gui@v1
         with:
           run: python -m pytest -s -v --color=yes


### PR DESCRIPTION
I think the repo itself should update the test action as it was done for the cookiecutter workflow template at https://github.com/napari/cookiecutter-napari-plugin/pull/149 right?