### PR TITLE
 MAINT: Go back to release pytest-cookies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest tox
-          pip install git+https://github.com/hackebrot/pytest-cookies.git@refs/pull/61/head
+          python -m pip install pytest pytest-cookies tox
 
       - name: Test
         uses: GabrielBB/xvfb-action@v1

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ toxworkdir = /tmp/.tox
 
 [testenv]
 deps = pytest
-       git+https://github.com/hackebrot/pytest-cookies.git@refs/pull/61/head
+       pytest-cookies
        tox
 commands = pytest -v {posargs:tests}
 


### PR DESCRIPTION
The fix needed for Windows has been merged and new release is out.
So the workaround of using a PR branch shouldn't be needed.
See discussion at https://github.com/napari/cookiecutter-napari-plugin/pull/143

This PR goes back to using release `pytest-cookies`.