### PR TITLE
Bugfix: check for underscores in plugin name

### DIFF
--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -13,6 +13,6 @@ if not re.match(r"^[a-z][_a-z0-9]+$", "{{cookiecutter.module_name}}"):
     logger.error(f"  More info: {link}")
     sys.exit(1)
 
-if re.match(r"_", "{{cookiecutter.plugin_name}}"):
+if re.search(r"_", "{{cookiecutter.plugin_name}}"):
     logger.error("PyPI.org and pip discourage package names with underscores.")
     sys.exit(1)


### PR DESCRIPTION
Bugfix for check for underscores in plugin name.
Must use re.search (not re.match) to detect an underscore anywhere in the plugin name string.

```python
import re

re.search(r"_", "plugin_name_with_underscores") # returns matches
# but
re.match(r"_", "plugin_name_with_underscores")  # returns None, because no underscore was detected at the *beginning* of this string.
```