### PR TITLE
Add `visibility` and `categories` to manifest and remove `.napari-hub/config.yml` file 

### DIFF
--- a/{{cookiecutter.plugin_name}}/.napari-hub/config.yml
+++ b/{{cookiecutter.plugin_name}}/.napari-hub/config.yml
@@ -1,9 +1,0 @@
-# You may use this file to customize how your plugin page appears
-# on the napari hub: https://www.napari-hub.org/
-# See their wiki for details https://github.com/chanzuckerberg/napari-hub/wiki
-
-# Please note that this file should only be used IN ADDITION to entering
-# metadata fields (such as summary, description, authors, and various URLS)
-# in your standard python package metadata (e.g. setup.cfg, setup.py, or
-# pyproject.toml), when you would like those fields to be displayed
-# differently on the hub than in the napari application.

--- a/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/napari.yaml
+++ b/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/napari.yaml
@@ -1,5 +1,9 @@
 name: {{cookiecutter.plugin_name}}
 display_name: {{cookiecutter.display_name}}
+# use 'hidden' to remove plugin from napari hub search results
+visibility: public
+# see https://napari.org/stable/plugins/manifest.html for valid categories
+categories: ["Annotation", "Segmentation", "Acquisition"]
 contributions:
   commands:{% if cookiecutter.include_reader_plugin == 'y' %}
     - id: {{cookiecutter.plugin_name}}.get_reader


### PR DESCRIPTION
Since the manifest supports `visibility` and `categories`, and the napari hub is being updated to read from these files, this PR updates the cookiecutter to add the two new fields to the manifest with brief instructions on how to use them, and removes the `.napari-hub/config.yml` file entirely.