### PR TITLE
Bugfix: move endif and reader-if so all widgets work if only widgets are give `y`

### DIFF
--- a/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/napari.yaml
+++ b/{{cookiecutter.plugin_name}}/src/{{cookiecutter.module_name}}/napari.yaml
@@ -26,10 +26,10 @@ contributions:
       title: Make threshold magic widget
     - id: {{cookiecutter.plugin_name}}.make_function_widget
       python_name: {{cookiecutter.module_name}}:threshold_autogenerate_widget
-      title: Make threshold function widget{% endif %}{% if cookiecutter.include_reader_plugin == 'y' %}
+      title: Make threshold function widget
     - id: {{cookiecutter.plugin_name}}.make_qwidget
       python_name: {{cookiecutter.module_name}}:ExampleQWidget
-      title: Make example QWidget
+      title: Make example QWidget{% endif %}{% if cookiecutter.include_reader_plugin == 'y' %}
   readers:
     - command: {{cookiecutter.plugin_name}}.get_reader
       accepts_directories: false


### PR DESCRIPTION
Closes: #172 

In https://github.com/napari/cookiecutter-napari-plugin/pull/168 when widgets got an update a logic error was introduced into napari.yaml. This shifts the endif and if to the proper line (after all of the widgets).


I tested locally and could reproduce the issue and this fixes it.
I wonder if we should try to extend the make and install test to try each of the plugin types individually?