### PR TITLE
[MAINT] use parametrize to test plugins with every answer combo

### DIFF
--- a/tests/test_create_template.py
+++ b/tests/test_create_template.py
@@ -47,7 +47,7 @@ def test_run_cookiecutter_and_plugin_tests(cookies, capsys, include_reader_plugi
     if include_writer_plugin == "y":
         assert (test_path / "test_writer.py").is_file()
     if include_sample_data_plugin == "y":
-        assert (test_path / test_sample_data.py").is_file()
+        assert (test_path / "test_sample_data.py").is_file()
     if include_widget_plugin == "y":
         assert (test_path / "test_widget.py").is_file()
 

--- a/tests/test_create_template.py
+++ b/tests/test_create_template.py
@@ -41,17 +41,18 @@ def test_run_cookiecutter_and_plugin_tests(cookies, capsys, include_reader_plugi
     assert result.project_path.joinpath("src").is_dir()
     assert result.project_path.joinpath("src", "foo_bar", "__init__.py").is_file()
 
+    test_path = result.project_path.joinpath("src", "foo_bar", "_tests")
     if include_reader_plugin == "y":
-        assert result.project_path.joinpath("src", "foo_bar", "_tests", "test_reader.py").is_file()
+        assert (test_path / "test_reader.py").is_file()
     if include_writer_plugin == "y":
-        assert result.project_path.joinpath("src", "foo_bar", "_tests", "test_writer.py").is_file()
+        assert (test_path / "test_writer.py").is_file()
     if include_sample_data_plugin == "y":
-        assert result.project_path.joinpath("src", "foo_bar", "_tests", "test_sample_data.py").is_file()
+        assert (test_path / test_sample_data.py").is_file()
     if include_widget_plugin == "y":
-        assert result.project_path.joinpath("src", "foo_bar", "_tests", "test_widget.py").is_file()
+        assert (test_path / "test_widget.py").is_file()
 
     # if all are `n` there are no modules or tests    
-    if not (include_reader_plugin == "n" and include_writer_plugin == "n" and include_sample_data_plugin == "n" and include_widget_plugin == "n"):
+    if "y" in {include_reader_plugin, include_writer_plugin, include_sample_data_plugin, include_widget_plugin}:
         run_tox(str(result.project_path))
 
 


### PR DESCRIPTION
In this PR I try to address the fact that tests failed to catch https://github.com/napari/cookiecutter-napari-plugin/issues/172  
which is to generate and test plugins for each combo of answers, except 4X `n` because that has no modules and no tests.