### PR TITLE
Update top-level linter settings in `pyproject.toml`

### DIFF
--- a/{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/{{cookiecutter.plugin_name}}/pyproject.toml
@@ -18,7 +18,7 @@ target-version = ['py38', 'py39', 'py310']
 
 [tool.ruff]
 line-length = 79
-select = [
+lint.select = [
     "E", "F", "W", #flake8
     "UP", # pyupgrade
     "I", # isort
@@ -31,7 +31,7 @@ select = [
     "PIE", # flake8-pie
     "SIM", # flake8-simplify
 ]
-ignore = [
+lint.ignore = [
     "E501", # line too long. let black handle this
     "UP006", "UP007", # type annotation. As using magicgui require runtime type annotation then we disable this.
     "SIM117", # flake8-simplify - some of merged with statements are not looking great with black, reanble after drop python 3.9


### PR DESCRIPTION
Closes: #176

Updates linter settings in `pyproject.toml` so that no depreciation warning is issued when pre-commit is run on the project