### PR TITLE
fix typo in `test_create_template.py`

### DIFF
--- a/tests/test_create_template.py
+++ b/tests/test_create_template.py
@@ -116,4 +116,4 @@ def test_pre_commit_validity(cookies, include_reader_plugin, include_writer_plug
     try:
         subprocess.run(["pre-commit", "run", "--all", "--show-diff-on-failure"], cwd=str(result.project_path), check=True, capture_output=True)
     except subprocess.CalledProcessError as e:
-        pytest.fail(f"pre-commit failed with output:\n{e.stdout.decode()}\nerrror:\n{e.stderr.decode()}")
+        pytest.fail(f"pre-commit failed with output:\n{e.stdout.decode()}\nerror:\n{e.stderr.decode()}")


### PR DESCRIPTION
I spotted a typo in test logs while working on [another pull request](https://github.com/napari/cookiecutter-napari-plugin/pull/175#issuecomment-2040377724): "error" was spelled with 3 'r's. Here's a quick fix.