### PR TITLE
Use dynamic package version only without setuptools_scm

### DIFF
--- a/{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/{{cookiecutter.plugin_name}}/pyproject.toml
@@ -75,9 +75,6 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools]
 include-package-data = true
 
-[tool.setuptools.dynamic]
-version = {attr = "{{cookiecutter.module_name}}.__init__.__version__"}
-
 [tool.setuptools.packages.find]
 where = ["src"]
 
@@ -87,6 +84,9 @@ where = ["src"]
 {% if cookiecutter.use_git_tags_for_versioning == 'y' and cookiecutter.plugin_name != "foo-bar" %}
 [tool.setuptools_scm]
 write_to = "src/{{cookiecutter.module_name}}/_version.py"
+{% else %}
+[tool.setuptools.dynamic]
+version = {attr = "{{cookiecutter.module_name}}.__init__.__version__"}
 {%- endif %}
 
 [tool.black]


### PR DESCRIPTION
Closes #185

Use dynamic version only when setuptools_scm is not used. 

When we use `setuptools_scm` the version file is not present during begin of the installation phase as it is generated then. The `setuptools_scm` will assign version properly. 