### PR TITLE
Do not create special case for plugins named napari-foobar

### DIFF
--- a/{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/{{cookiecutter.plugin_name}}/pyproject.toml
@@ -65,7 +65,7 @@ testing = [
 {%- endif %}
 
 [build-system]
-{% if cookiecutter.use_git_tags_for_versioning == 'y' and cookiecutter.plugin_name != "foo-bar" -%}
+{% if cookiecutter.use_git_tags_for_versioning == 'y' -%}
 requires = ["setuptools>=42.0.0", "wheel", "setuptools_scm"]
 {%- else -%}
 requires = ["setuptools>=42.0.0", "wheel"]
@@ -81,7 +81,7 @@ where = ["src"]
 [tool.setuptools.package-data]
 "*" = ["*.yaml"]
 
-{% if cookiecutter.use_git_tags_for_versioning == 'y' and cookiecutter.plugin_name != "foo-bar" %}
+{% if cookiecutter.use_git_tags_for_versioning == 'y' %}
 [tool.setuptools_scm]
 write_to = "src/{{cookiecutter.module_name}}/_version.py"
 {% else %}


### PR DESCRIPTION
Can anyone tell me why this special case was written in the first place?

Either we have a *really* good reason for it, and add comments explaining the need for this special situation,
OR
We remove the special case treatment, and handle all plugins the same way.