### PR TITLE
Update aganders/headless-gui to silence nodejs warning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,6 @@ jobs:
           python -m pip install pytest pytest-cookies tox
 
       - name: Test
-        uses: aganders3/headless-gui@v1
+        uses: aganders3/headless-gui@v2
         with:
           run: python -m pytest -s -v --color=yes

--- a/{{cookiecutter.plugin_name}}/.github/workflows/test_and_deploy.yml
+++ b/{{cookiecutter.plugin_name}}/.github/workflows/test_and_deploy.yml
@@ -55,7 +55,7 @@ jobs:
 
       # this runs the platform-specific tests declared in tox.ini
       - name: Test with tox
-        uses: aganders3/headless-gui@v1
+        uses: aganders3/headless-gui@v2
         with:
           run: python -m tox
         env:


### PR DESCRIPTION
When the github actions CI tests run, we see this nodejs warning:
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: aganders3/headless-gui@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

This has been fixed by https://github.com/aganders3/headless-gui/pull/11
The fix is available for versions `aganders3/headless-gui@v2.2` and above.